### PR TITLE
Add runtime login window

### DIFF
--- a/AzurePrOps/AzurePrOps/App.axaml.cs
+++ b/AzurePrOps/AzurePrOps/App.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia;
+using System;
 using Avalonia.Controls.ApplicationLifetimes;
+using System.Reactive.Linq;
 using Avalonia.Markup.Xaml;
 using AzurePrOps.ViewModels;
 using AzurePrOps.Views;
@@ -17,10 +19,21 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainWindow
+            var loginVm = new LoginWindowViewModel();
+            var loginWindow = new LoginWindow { DataContext = loginVm };
+
+            loginVm.ConnectCommand.Subscribe(settings =>
             {
-                DataContext = new MainWindowViewModel(),
-            };
+                var mainWindow = new MainWindow
+                {
+                    DataContext = new MainWindowViewModel(settings),
+                };
+                desktop.MainWindow = mainWindow;
+                mainWindow.Show();
+                loginWindow.Close();
+            });
+
+            desktop.MainWindow = loginWindow;
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/AzurePrOps/AzurePrOps/Models/ConnectionSettings.cs
+++ b/AzurePrOps/AzurePrOps/Models/ConnectionSettings.cs
@@ -1,0 +1,8 @@
+namespace AzurePrOps.Models;
+
+public record ConnectionSettings(
+    string Organization,
+    string Project,
+    string Repository,
+    string PersonalAccessToken,
+    string ReviewerId);

--- a/AzurePrOps/AzurePrOps/ViewModels/LoginWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/LoginWindowViewModel.cs
@@ -1,0 +1,52 @@
+using ReactiveUI;
+using System.Reactive;
+using System.Threading.Tasks;
+using AzurePrOps.Models;
+
+namespace AzurePrOps.ViewModels;
+
+public class LoginWindowViewModel : ViewModelBase
+{
+    private string _organization = string.Empty;
+    public string Organization
+    {
+        get => _organization;
+        set => this.RaiseAndSetIfChanged(ref _organization, value);
+    }
+
+    private string _project = string.Empty;
+    public string Project
+    {
+        get => _project;
+        set => this.RaiseAndSetIfChanged(ref _project, value);
+    }
+
+    private string _repository = string.Empty;
+    public string Repository
+    {
+        get => _repository;
+        set => this.RaiseAndSetIfChanged(ref _repository, value);
+    }
+
+    private string _personalAccessToken = string.Empty;
+    public string PersonalAccessToken
+    {
+        get => _personalAccessToken;
+        set => this.RaiseAndSetIfChanged(ref _personalAccessToken, value);
+    }
+
+    private string _reviewerId = string.Empty;
+    public string ReviewerId
+    {
+        get => _reviewerId;
+        set => this.RaiseAndSetIfChanged(ref _reviewerId, value);
+    }
+
+    public ReactiveCommand<Unit, ConnectionSettings> ConnectCommand { get; }
+
+    public LoginWindowViewModel()
+    {
+        ConnectCommand = ReactiveCommand.Create(() =>
+            new ConnectionSettings(Organization, Project, Repository, PersonalAccessToken, ReviewerId));
+    }
+}

--- a/AzurePrOps/AzurePrOps/Views/LoginWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/LoginWindow.axaml
@@ -1,0 +1,18 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:AzurePrOps.ViewModels"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
+        x:Class="AzurePrOps.Views.LoginWindow"
+        x:DataType="vm:LoginWindowViewModel"
+        Title="Connect">
+    <StackPanel Margin="10" Spacing="6">
+        <TextBox Watermark="Organization" Text="{Binding Organization}"/>
+        <TextBox Watermark="Project" Text="{Binding Project}"/>
+        <TextBox Watermark="Repository" Text="{Binding Repository}"/>
+        <TextBox Watermark="Reviewer ID" Text="{Binding ReviewerId}"/>
+        <TextBox Watermark="PAT" Text="{Binding PersonalAccessToken}"/>
+        <Button Content="Connect" Command="{Binding ConnectCommand}" Width="100" HorizontalAlignment="Right"/>
+    </StackPanel>
+</Window>

--- a/AzurePrOps/AzurePrOps/Views/LoginWindow.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Views/LoginWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using AzurePrOps.ViewModels;
+
+namespace AzurePrOps.Views;
+
+public partial class LoginWindow : Window
+{
+    public LoginWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # AzurePrOps
+
+A minimal Avalonia UI tool for interacting with Azure DevOps pull requests.
+
+Upon launch, the application now prompts for your organization, project, repository, reviewer id and personal access token (PAT). These values are stored only for the current session and remove the need to edit the source code when connecting to different projects.


### PR DESCRIPTION
## Summary
- prompt for connection details at startup
- move connection info to a new `ConnectionSettings` model
- wire `MainWindowViewModel` to use runtime settings
- update README

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685947b717e08320a35782d08c841f9c