### PR TITLE
Improve login convenience

### DIFF
--- a/AzurePrOps/AzurePrOps.AzureConnection/Models/NamedItem.cs
+++ b/AzurePrOps/AzurePrOps.AzureConnection/Models/NamedItem.cs
@@ -1,0 +1,3 @@
+namespace AzurePrOps.AzureConnection.Models;
+
+public record NamedItem(string Id, string Name);

--- a/AzurePrOps/AzurePrOps/App.axaml.cs
+++ b/AzurePrOps/AzurePrOps/App.axaml.cs
@@ -22,14 +22,25 @@ public partial class App : Application
             var loginVm = new LoginWindowViewModel();
             var loginWindow = new LoginWindow { DataContext = loginVm };
 
-            loginVm.ConnectCommand.Subscribe(settings =>
+            loginVm.LoginCommand.Subscribe(async info =>
             {
-                var mainWindow = new MainWindow
+                var selectVm = new ProjectSelectionWindowViewModel(info.PersonalAccessToken, info.ReviewerId);
+                await selectVm.LoadAsync();
+                var selectWindow = new ProjectSelectionWindow { DataContext = selectVm };
+
+                selectVm.ConnectCommand.Subscribe(settings =>
                 {
-                    DataContext = new MainWindowViewModel(settings),
-                };
-                desktop.MainWindow = mainWindow;
-                mainWindow.Show();
+                    var mainWindow = new MainWindow
+                    {
+                        DataContext = new MainWindowViewModel(settings),
+                    };
+                    desktop.MainWindow = mainWindow;
+                    mainWindow.Show();
+                    selectWindow.Close();
+                });
+
+                desktop.MainWindow = selectWindow;
+                selectWindow.Show();
                 loginWindow.Close();
             });
 

--- a/AzurePrOps/AzurePrOps/Models/ConnectionSettingsStorage.cs
+++ b/AzurePrOps/AzurePrOps/Models/ConnectionSettingsStorage.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace AzurePrOps.Models;
+
+public static class ConnectionSettingsStorage
+{
+    private static readonly string FilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "AzurePrOps",
+        "settings.json");
+
+    public static bool TryLoad(out ConnectionSettings? settings)
+    {
+        settings = null;
+        try
+        {
+            if (!File.Exists(FilePath))
+                return false;
+
+            var json = File.ReadAllText(FilePath);
+            settings = JsonSerializer.Deserialize<ConnectionSettings>(json);
+            return settings != null;
+        }
+        catch
+        {
+            settings = null;
+            return false;
+        }
+    }
+
+    public static void Save(ConnectionSettings settings)
+    {
+        var dir = Path.GetDirectoryName(FilePath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = JsonSerializer.Serialize(settings);
+        File.WriteAllText(FilePath, json);
+    }
+}

--- a/AzurePrOps/AzurePrOps/Models/LoginInfo.cs
+++ b/AzurePrOps/AzurePrOps/Models/LoginInfo.cs
@@ -1,0 +1,3 @@
+namespace AzurePrOps.Models;
+
+public record LoginInfo(string ReviewerId, string PersonalAccessToken);

--- a/AzurePrOps/AzurePrOps/ViewModels/LoginWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/LoginWindowViewModel.cs
@@ -1,31 +1,19 @@
 using ReactiveUI;
 using System.Reactive;
-using System.Threading.Tasks;
 using AzurePrOps.Models;
+using AzurePrOps.AzureConnection.Services;
 
 namespace AzurePrOps.ViewModels;
 
 public class LoginWindowViewModel : ViewModelBase
 {
-    private string _organization = string.Empty;
-    public string Organization
-    {
-        get => _organization;
-        set => this.RaiseAndSetIfChanged(ref _organization, value);
-    }
+    private readonly AzureDevOpsClient _client = new();
 
-    private string _project = string.Empty;
-    public string Project
+    private string _email = string.Empty;
+    public string Email
     {
-        get => _project;
-        set => this.RaiseAndSetIfChanged(ref _project, value);
-    }
-
-    private string _repository = string.Empty;
-    public string Repository
-    {
-        get => _repository;
-        set => this.RaiseAndSetIfChanged(ref _repository, value);
+        get => _email;
+        set => this.RaiseAndSetIfChanged(ref _email, value);
     }
 
     private string _personalAccessToken = string.Empty;
@@ -35,18 +23,19 @@ public class LoginWindowViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _personalAccessToken, value);
     }
 
-    private string _reviewerId = string.Empty;
-    public string ReviewerId
-    {
-        get => _reviewerId;
-        set => this.RaiseAndSetIfChanged(ref _reviewerId, value);
-    }
-
-    public ReactiveCommand<Unit, ConnectionSettings> ConnectCommand { get; }
+    public ReactiveCommand<Unit, LoginInfo> LoginCommand { get; }
 
     public LoginWindowViewModel()
     {
-        ConnectCommand = ReactiveCommand.Create(() =>
-            new ConnectionSettings(Organization, Project, Repository, PersonalAccessToken, ReviewerId));
+        if (ConnectionSettingsStorage.TryLoad(out var loaded))
+        {
+            PersonalAccessToken = loaded!.PersonalAccessToken;
+        }
+
+        LoginCommand = ReactiveCommand.CreateFromTask(async () =>
+        {
+            var reviewerId = await _client.GetUserIdAsync(PersonalAccessToken);
+            return new LoginInfo(reviewerId, PersonalAccessToken);
+        });
     }
 }

--- a/AzurePrOps/AzurePrOps/ViewModels/ProjectSelectionWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/ProjectSelectionWindowViewModel.cs
@@ -1,0 +1,105 @@
+using ReactiveUI;
+using System.Collections.ObjectModel;
+using AzurePrOps.AzureConnection.Models;
+using AzurePrOps.AzureConnection.Services;
+using AzurePrOps.Models;
+using System.Reactive;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AzurePrOps.ViewModels;
+
+public class ProjectSelectionWindowViewModel : ViewModelBase
+{
+    private readonly AzureDevOpsClient _client = new();
+    private readonly string _personalAccessToken;
+    private readonly string _reviewerId;
+
+    public ObservableCollection<NamedItem> Organizations { get; } = new();
+    public ObservableCollection<NamedItem> Projects { get; } = new();
+    public ObservableCollection<NamedItem> Repositories { get; } = new();
+
+    private NamedItem? _selectedOrganization;
+    public NamedItem? SelectedOrganization
+    {
+        get => _selectedOrganization;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedOrganization, value);
+            _ = LoadProjectsAsync();
+        }
+    }
+
+    private NamedItem? _selectedProject;
+    public NamedItem? SelectedProject
+    {
+        get => _selectedProject;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedProject, value);
+            _ = LoadRepositoriesAsync();
+        }
+    }
+
+    private NamedItem? _selectedRepository;
+    public NamedItem? SelectedRepository
+    {
+        get => _selectedRepository;
+        set => this.RaiseAndSetIfChanged(ref _selectedRepository, value);
+    }
+
+    public ReactiveCommand<Unit, ConnectionSettings> ConnectCommand { get; }
+
+    public ProjectSelectionWindowViewModel(string personalAccessToken, string reviewerId)
+    {
+        _personalAccessToken = personalAccessToken;
+        _reviewerId = reviewerId;
+
+        ConnectCommand = ReactiveCommand.Create(() =>
+        {
+            var settings = new ConnectionSettings(
+                SelectedOrganization?.Name ?? string.Empty,
+                SelectedProject?.Name ?? string.Empty,
+                SelectedRepository?.Id ?? string.Empty,
+                _personalAccessToken,
+                _reviewerId);
+            ConnectionSettingsStorage.Save(settings);
+            return settings;
+        });
+    }
+
+    public async Task LoadAsync()
+    {
+        Organizations.Clear();
+        var userId = _reviewerId;
+        var orgs = await _client.GetOrganizationsAsync(userId, _personalAccessToken);
+        foreach (var o in orgs)
+            Organizations.Add(o);
+        SelectedOrganization = Organizations.FirstOrDefault();
+    }
+
+    private async Task LoadProjectsAsync()
+    {
+        Projects.Clear();
+        Repositories.Clear();
+        if (SelectedOrganization == null)
+            return;
+
+        var projects = await _client.GetProjectsAsync(SelectedOrganization.Name, _personalAccessToken);
+        foreach (var p in projects)
+            Projects.Add(p);
+        SelectedProject = Projects.FirstOrDefault();
+    }
+
+    private async Task LoadRepositoriesAsync()
+    {
+        Repositories.Clear();
+        if (SelectedOrganization == null || SelectedProject == null)
+            return;
+
+        var repos = await _client.GetRepositoriesAsync(SelectedOrganization.Name, SelectedProject.Name, _personalAccessToken);
+        foreach (var r in repos)
+            Repositories.Add(r);
+        SelectedRepository = Repositories.FirstOrDefault();
+    }
+}

--- a/AzurePrOps/AzurePrOps/Views/LoginWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/LoginWindow.axaml
@@ -3,16 +3,13 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:AzurePrOps.ViewModels"
-        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200"
         x:Class="AzurePrOps.Views.LoginWindow"
         x:DataType="vm:LoginWindowViewModel"
-        Title="Connect">
+        Title="Login">
     <StackPanel Margin="10" Spacing="6">
-        <TextBox Watermark="Organization" Text="{Binding Organization}"/>
-        <TextBox Watermark="Project" Text="{Binding Project}"/>
-        <TextBox Watermark="Repository" Text="{Binding Repository}"/>
-        <TextBox Watermark="Reviewer ID" Text="{Binding ReviewerId}"/>
+        <TextBox Watermark="Email" Text="{Binding Email}"/>
         <TextBox Watermark="PAT" Text="{Binding PersonalAccessToken}"/>
-        <Button Content="Connect" Command="{Binding ConnectCommand}" Width="100" HorizontalAlignment="Right"/>
+        <Button Content="Login" Command="{Binding LoginCommand}" Width="100" HorizontalAlignment="Right"/>
     </StackPanel>
 </Window>

--- a/AzurePrOps/AzurePrOps/Views/ProjectSelectionWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/ProjectSelectionWindow.axaml
@@ -1,0 +1,28 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:AzurePrOps.ViewModels"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
+        x:Class="AzurePrOps.Views.ProjectSelectionWindow"
+        x:DataType="vm:ProjectSelectionWindowViewModel"
+        Title="Select Project">
+    <StackPanel Margin="10" Spacing="6">
+        <ComboBox ItemsSource="{Binding Organizations}" SelectedItem="{Binding SelectedOrganization}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate><TextBlock Text="{Binding Name}"/></DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+        <ComboBox ItemsSource="{Binding Projects}" SelectedItem="{Binding SelectedProject}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate><TextBlock Text="{Binding Name}"/></DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+        <ComboBox ItemsSource="{Binding Repositories}" SelectedItem="{Binding SelectedRepository}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate><TextBlock Text="{Binding Name}"/></DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+        <Button Content="Continue" Command="{Binding ConnectCommand}" Width="100" HorizontalAlignment="Right"/>
+    </StackPanel>
+</Window>

--- a/AzurePrOps/AzurePrOps/Views/ProjectSelectionWindow.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Views/ProjectSelectionWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace AzurePrOps.Views;
+
+public partial class ProjectSelectionWindow : Window
+{
+    public ProjectSelectionWindow()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add NamedItem model and REST API helpers for organizations, projects, and repos
- simplify login window to require only email and PAT
- add project selection window to pick organization/project/repository after login
- save final connection settings

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685965c830f88320a1f8e3ec46ebc915