### PR TITLE
Expand PR details window

### DIFF
--- a/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
@@ -243,7 +243,7 @@ public class MainWindowViewModel : ViewModelBase
 
             Dispatcher.UIThread.InvokeAsync(() =>
             {
-                var vm = new PullRequestDetailsWindowViewModel(SelectedPullRequest);
+                var vm = new PullRequestDetailsWindowViewModel(SelectedPullRequest, Comments);
                 var window = new PullRequestDetailsWindow { DataContext = vm };
                 window.Show();
             });

--- a/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
@@ -4,6 +4,8 @@ using System.Reactive;
 using Avalonia.Threading;
 using ReactiveUI;
 using AzurePrOps.AzureConnection.Models;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace AzurePrOps.ViewModels;
 
@@ -11,11 +13,17 @@ public class PullRequestDetailsWindowViewModel : ViewModelBase
 {
     public PullRequestInfo PullRequest { get; }
 
+    public ObservableCollection<PullRequestComment> Comments { get; }
+
     public ReactiveCommand<Unit, Unit> OpenInBrowserCommand { get; }
 
-    public PullRequestDetailsWindowViewModel(PullRequestInfo pullRequest)
+    public PullRequestDetailsWindowViewModel(PullRequestInfo pullRequest, IEnumerable<PullRequestComment>? comments = null)
     {
         PullRequest = pullRequest;
+        Comments = comments != null
+            ? new ObservableCollection<PullRequestComment>(comments)
+            : new ObservableCollection<PullRequestComment>();
+
         OpenInBrowserCommand = ReactiveCommand.Create(() =>
         {
             if (string.IsNullOrWhiteSpace(PullRequest.Url))

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
@@ -4,20 +4,52 @@
         x:Class="AzurePrOps.Views.PullRequestDetailsWindow"
         x:DataType="vm:PullRequestDetailsWindowViewModel"
         Title="Pull Request Details"
-        Width="400"
-        Height="450">
-    <StackPanel Margin="10" Spacing="6">
-        <TextBlock Text="{Binding PullRequest.Title}" FontWeight="Bold" FontSize="16"/>
-        <TextBlock Text="{Binding PullRequest.Creator}" FontStyle="Italic"/>
-        <TextBlock Text="{Binding PullRequest.Created}"/>
-        <TextBlock Text="{Binding PullRequest.Status}"/>
-        <TextBlock Text="Source: {Binding PullRequest.SourceBranch}" TextWrapping="Wrap"/>
-        <TextBlock Text="Target: {Binding PullRequest.TargetBranch}" TextWrapping="Wrap"/>
-        <TextBlock Text="{Binding PullRequest.ReviewersText}" TextWrapping="Wrap"/>
-        <Button Content="Open in Browser"
-                Command="{Binding OpenInBrowserCommand}"
-                HorizontalAlignment="Right"
-                Width="150"
-                Margin="0,10,0,0"/>
-    </StackPanel>
+        Width="600"
+        Height="650">
+    <ScrollViewer Margin="10" VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="6">
+            <TextBlock Text="{Binding PullRequest.Title}" FontWeight="Bold" FontSize="16"/>
+            <TextBlock Text="{Binding PullRequest.Creator}" FontStyle="Italic"/>
+            <TextBlock Text="{Binding PullRequest.Created}"/>
+            <TextBlock Text="{Binding PullRequest.Status}"/>
+            <TextBlock Text="Source: {Binding PullRequest.SourceBranch}" TextWrapping="Wrap"/>
+            <TextBlock Text="Target: {Binding PullRequest.TargetBranch}" TextWrapping="Wrap"/>
+
+            <TextBlock Text="Participants" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ListBox ItemsSource="{Binding PullRequest.Reviewers}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"/>
+                            <TextBlock Text="({Binding Vote})" Foreground="Gray"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <TextBlock Text="Comments" FontWeight="Bold" Margin="0,10,0,0"/>
+            <ListBox ItemsSource="{Binding Comments}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="0,0,0,4">
+                            <TextBlock Text="{Binding Author}" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding PostedDate}" FontStyle="Italic" FontSize="10"/>
+                            <TextBlock Text="{Binding Content}" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+
+            <TextBlock Text="Changes" FontWeight="Bold" Margin="0,10,0,0"/>
+            <Border Height="200" Background="#FFF5F5F5" BorderBrush="#FFCCCCCC" BorderThickness="1">
+                <TextBlock Text="Code diff will appear here" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Gray"/>
+            </Border>
+
+            <Button Content="Open in Browser"
+                    Command="{Binding OpenInBrowserCommand}"
+                    HorizontalAlignment="Right"
+                    Width="150"
+                    Margin="0,10,0,0"/>
+        </StackPanel>
+    </ScrollViewer>
 </Window>


### PR DESCRIPTION
## Summary
- pass comments to PullRequestDetailsWindowViewModel
- add Comments property in PR details view model
- redesign PullRequestDetailsWindow UI to show participants and comments and reserve space for code changes

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6859bf8d1c408320a39cac1289d722c7