### PR TITLE
Improve color contrast for readability

### DIFF
--- a/AzurePrOps/AzurePrOps/App.axaml
+++ b/AzurePrOps/AzurePrOps/App.axaml
@@ -2,8 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:AzurePrOps"
              xmlns:converters="using:AzurePrOps.Converters"
-             x:Class="AzurePrOps.App"
-             RequestedThemeVariant="Default">
+            x:Class="AzurePrOps.App"
+            RequestedThemeVariant="Dark">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
     <Application.DataTemplates>

--- a/AzurePrOps/AzurePrOps/Styles/Styles.xaml
+++ b/AzurePrOps/AzurePrOps/Styles/Styles.xaml
@@ -1,7 +1,15 @@
 <Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Styles.Resources>
-        <SolidColorBrush x:Key="BackgroundBrush" Color="#F9F9F9" />
-        <SolidColorBrush x:Key="PrimaryBrush" Color="#333333" />
+        <!-- GitKraken-inspired dark theme colors -->
+        <Color x:Key="AccentColor">#31A8FF</Color>
+        <SolidColorBrush x:Key="AccentBrush" Color="{DynamicResource AccentColor}" />
+
+        <SolidColorBrush x:Key="BackgroundBrush" Color="#1E2227" />
+        <SolidColorBrush x:Key="PrimaryBrush" Color="#E3E3E3" />
+
+        <SolidColorBrush x:Key="CardBackgroundBrush" Color="#2B3137" />
+        <SolidColorBrush x:Key="BorderBrush" Color="#3C444C" />
+        <SolidColorBrush x:Key="ErrorBrush" Color="#FF5555" />
     </Styles.Resources>
 
     <Style Selector="Window">
@@ -9,6 +17,11 @@
     </Style>
 
     <Style Selector="TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryBrush}" />
+    </Style>
+
+    <Style Selector="Button">
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource PrimaryBrush}" />
     </Style>
 

--- a/AzurePrOps/AzurePrOps/Views/MainWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/MainWindow.axaml
@@ -55,7 +55,10 @@
             <ListBox Grid.Row="3" ItemsSource="{Binding PullRequests}" SelectedItem="{Binding SelectedPullRequest}">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <Border Padding="4" BorderBrush="#DDDDDD" BorderThickness="0,0,0,1">
+                    <Border Padding="4"
+                           Background="{DynamicResource CardBackgroundBrush}"
+                           BorderBrush="{DynamicResource BorderBrush}"
+                           BorderThickness="0,0,0,1">
                         <StackPanel Spacing="2">
                             <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
                                 <TextBlock Text="{Binding Status, Converter={StaticResource StatusToIcon}}"

--- a/AzurePrOps/AzurePrOps/Views/ProjectSelectionWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/ProjectSelectionWindow.axaml
@@ -117,15 +117,15 @@
         </StackPanel>
 
         <Border
-            Background="#FFF5F5F5"
-            BorderBrush="#FFCCCCCC"
+            Background="{DynamicResource CardBackgroundBrush}"
+            BorderBrush="{DynamicResource BorderBrush}"
             BorderThickness="1"
             Grid.Row="4"
             IsVisible="{Binding !!ErrorMessage}"
             Margin="0,0,0,10"
             Padding="10">
             <TextBlock
-                Foreground="#CC0000"
+                Foreground="{DynamicResource ErrorBrush}"
                 Text="{Binding ErrorMessage}"
                 TextWrapping="Wrap" />
         </Border>

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
@@ -59,7 +59,10 @@
             </ListBox>
 
             <TextBlock Text="Changes" FontWeight="Bold" Margin="0,10,0,0"/>
-            <Border Height="200" Background="#FFF5F5F5" BorderBrush="#FFCCCCCC" BorderThickness="1">
+            <Border Height="200"
+                    Background="{DynamicResource CardBackgroundBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}"
+                    BorderThickness="1">
                 <TextBlock Text="Code diff will appear here" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="Gray"/>
             </Border>
 


### PR DESCRIPTION
## Summary
- update colors in `Styles.xaml` to improve text/background contrast
- adopt dark theme based on GitKraken style

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6859c97ff4808320a407ea9968cdd2d5