### PR TITLE
Fix DiffViewer rendering on load

### DIFF
--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -117,7 +117,13 @@ namespace AzurePrOps.Controls
         public string NewText { get => GetValue(NewTextProperty); set => SetValue(NewTextProperty, value); }
         public DiffViewMode ViewMode { get => GetValue(ViewModeProperty); set => SetValue(ViewModeProperty, value); }
 
-        public DiffViewer() { InitializeComponent(); }
+        public DiffViewer()
+        {
+            InitializeComponent();
+            // Ensure initial rendering in case bound properties were set
+            // before InitializeComponent assigned the visual elements.
+            Render();
+        }
 
         private void InitializeComponent()
         {


### PR DESCRIPTION
## Summary
- ensure DiffViewer renders initial diff even if bindings were set before InitializeComponent

## Testing
- `dotnet build AzurePrOps.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685a7ef5f4688320b11b71be180661c6