### PR TITLE
Add manual diff by files

### DIFF
--- a/AzurePrOps/AzurePrOps.ReviewLogic/Services/IPullRequestService.cs
+++ b/AzurePrOps/AzurePrOps.ReviewLogic/Services/IPullRequestService.cs
@@ -6,6 +6,7 @@ public interface IPullRequestService
 {
     (string oldText, string newText) LoadDiff(string repositoryPath, int pullRequestId);
     Task<IReadOnlyList<FileDiff>> GetPullRequestDiffAsync(string organization, string project, string repositoryId, int pullRequestId, string personalAccessToken);
+    Task<IReadOnlyList<FileDiff>> GetPullRequestDiffByFilesAsync(string organization, string project, string repositoryId, int pullRequestId, string personalAccessToken);
     Task<IReadOnlyList<PullRequestInfo>> GetPullRequestsAsync(string organization, string project, string repositoryId, string personalAccessToken);
     void SetErrorHandler(Action<string> handler);
 }


### PR DESCRIPTION
## Summary
- add new API `GetPullRequestDiffByFilesAsync` to fetch file contents and build diffs
- expose manual diff generation in AzureDevOps client and services
- implement manual diff for local Git pull requests

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -clp:ErrorsOnly`
- `dotnet test AzurePrOps/AzurePrOps.sln -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_685acc657eb48320a482c6ce78c13ec5