### PR TITLE
Fix file diff retrieval

### DIFF
--- a/AzurePrOps/AzurePrOps.AzureConnection/Services/AzureDevOpsClient.DirectDiff.cs
+++ b/AzurePrOps/AzurePrOps.AzureConnection/Services/AzureDevOpsClient.DirectDiff.cs
@@ -135,9 +135,9 @@ public partial class AzureDevOpsClient
                 var newObjectId = item.TryGetProperty("objectId", out var newIdProp) ? 
                     newIdProp.GetString() : null;
 
-                var oldObjectId = change.TryGetProperty("originalPath", out var _) ?
-                    (item.TryGetProperty("originalObjectId", out var oldIdProp) ? 
-                        oldIdProp.GetString() : null) : null;
+                var oldObjectId = change.TryGetProperty("originalObjectId", out var oldIdProp)
+                    ? oldIdProp.GetString()
+                    : null;
 
                 // Fetch the content of both versions and create a diff
                 var (oldContent, newContent) = await GetFileContents(

--- a/AzurePrOps/AzurePrOps.ReviewLogic/Services/AzureDevOpsPullRequestService.cs
+++ b/AzurePrOps/AzurePrOps.ReviewLogic/Services/AzureDevOpsPullRequestService.cs
@@ -270,9 +270,9 @@ namespace AzurePrOps.ReviewLogic.Services
                     var newObjectId = item.TryGetProperty("objectId", out var newIdProp) ? 
                         newIdProp.GetString() : null;
 
-                    var oldObjectId = change.TryGetProperty("originalPath", out var _) ?
-                        (item.TryGetProperty("originalObjectId", out var oldIdProp) ? 
-                            oldIdProp.GetString() : null) : null;
+                    var oldObjectId = change.TryGetProperty("originalObjectId", out var oldIdProp)
+                        ? oldIdProp.GetString()
+                        : null;
 
                     // Fetch the content of both versions
                     var (oldContent, newContent) = await GetFileContents(


### PR DESCRIPTION
## Summary
- parse `originalObjectId` from diff responses when fetching file diffs
- ensure old commit ID is retrieved correctly for diff generation

## Testing
- `dotnet test AzurePrOps/AzurePrOps.sln`
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685ae21003d88320978ad8024142519a