### PR TITLE
Improve raw diff fallback

### DIFF
--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml.cs
@@ -63,6 +63,19 @@ public partial class PullRequestDetailsWindow : Window
                             Console.WriteLine($"  Generated OldText: {oldText.Length} chars, NewText: {newText.Length} chars");
                         }
                     }
+
+                    // If parsing still yields empty results, show the raw diff so the viewer isn't blank
+                    if (string.IsNullOrEmpty(oldText) && string.IsNullOrEmpty(newText))
+                    {
+                        Console.WriteLine("  Could not parse diff content - falling back to raw diff display");
+                        oldText = "[Unable to parse diff]\n";
+                        newText = fileDiff.Diff;
+                    }
+                    else if (string.Equals(oldText, newText, StringComparison.Ordinal) && !string.IsNullOrEmpty(fileDiff.Diff))
+                    {
+                        Console.WriteLine("  Parsed diff identical - appending raw diff to new text");
+                        newText += "\n\n[DIFF]\n" + fileDiff.Diff;
+                    }
                 }
 
                 // For new files, ensure we show the changes properly


### PR DESCRIPTION
## Summary
- show more useful raw diff when parsing fails
- append diff if parsed content ends up identical

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln --no-restore`
- `dotnet test AzurePrOps/AzurePrOps.sln --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_685ae76d729c8320b24bbe31aadef71d