### PR TITLE
Improve DiffViewer visibility and logging

### DIFF
--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml
@@ -140,6 +140,8 @@
                     MinHeight="250"
                     VerticalAlignment="Stretch"
                     VerticalScrollBarVisibility="Visible"
+                    Background="{DynamicResource CardBackgroundBrush}"
+                    Foreground="{DynamicResource PrimaryBrush}"
                     x:Name="OldEditor" />
             </Grid>
         </Border>
@@ -173,6 +175,8 @@
                     MinHeight="250"
                     VerticalAlignment="Stretch"
                     VerticalScrollBarVisibility="Visible"
+                    Background="{DynamicResource CardBackgroundBrush}"
+                    Foreground="{DynamicResource PrimaryBrush}"
                     x:Name="NewEditor" />
             </Grid>
         </Border>

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -107,6 +107,8 @@ namespace AzurePrOps.Controls
         {
             base.OnDataContextChanged(e);
 
+            Console.WriteLine($"OnDataContextChanged: {DataContext?.GetType().Name ?? "null"}");
+
             if (DataContext is FileDiff diff)
             {
                 // Assign bound texts when the DataContext changes so the viewer
@@ -225,6 +227,12 @@ namespace AzurePrOps.Controls
                 _newEditor.Background = bgBrush;
                 Console.WriteLine($"OldEditor colors - FG: {fgBrush}, BG: {bgBrush}");
                 Console.WriteLine($"NewEditor colors - FG: {fgBrush}, BG: {bgBrush}");
+
+                if (fgBrush is ISolidColorBrush fgSolid && bgBrush is ISolidColorBrush bgSolid)
+                {
+                    bool sameColor = fgSolid.Color.ToUInt32() == bgSolid.Color.ToUInt32();
+                    Console.WriteLine($"Foreground matches background? {sameColor}");
+                }
             }
 
             // Set explicit height for better visibility
@@ -269,13 +277,20 @@ namespace AzurePrOps.Controls
             _newEditor.InvalidateVisual();
             _oldEditor.TextArea.TextView.InvalidateVisual();
             _newEditor.TextArea.TextView.InvalidateVisual();
-            Console.WriteLine("Editors invalidated for redraw");
+            _oldEditor.TextArea.TextView.EnsureVisualLines();
+            _newEditor.TextArea.TextView.EnsureVisualLines();
+            Console.WriteLine($"Editors invalidated for redraw");
+            Console.WriteLine($"VisualLines valid? old: {_oldEditor.TextArea.TextView.VisualLinesValid}, new: {_newEditor.TextArea.TextView.VisualLinesValid}");
 
             Console.WriteLine($"Set document text - Old: {oldTextValue.Length} bytes, New: {newTextValue.Length} bytes");
             Console.WriteLine($"OldEditor.Document length now: {_oldEditor.Document.TextLength}");
             Console.WriteLine($"NewEditor.Document length now: {_newEditor.Document.TextLength}");
+            Console.WriteLine($"OldEditor line count: {_oldEditor.Document.LineCount}");
+            Console.WriteLine($"NewEditor line count: {_newEditor.Document.LineCount}");
             Console.WriteLine($"Old text preview: '{oldTextValue.Substring(0, Math.Min(100, oldTextValue.Length))}'");
             Console.WriteLine($"New text preview: '{newTextValue.Substring(0, Math.Min(100, newTextValue.Length))}'");
+            Console.WriteLine($"Document first lines - old: '{_oldEditor.Document.GetText(0, Math.Min(100, _oldEditor.Document.TextLength))}'");
+            Console.WriteLine($"Document first lines - new: '{_newEditor.Document.GetText(0, Math.Min(100, _newEditor.Document.TextLength))}'");
 
             // Clear previous transformers
             _oldEditor.TextArea.TextView.LineTransformers.Clear();

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -117,6 +117,14 @@ namespace AzurePrOps.Controls
                 NewText = diff.NewText ?? string.Empty;
                 _currentDiff = diff;
                 Console.WriteLine($"DataContext changed to FileDiff: {diff.FilePath}");
+
+                // Render again once the control is fully loaded to ensure the
+                // text appears even if DataContext was set before loading
+                Dispatcher.UIThread.Post(() =>
+                {
+                    Console.WriteLine("Post-DataContextChanged render");
+                    Render();
+                }, DispatcherPriority.Loaded);
             }
             else
             {
@@ -250,6 +258,13 @@ namespace AzurePrOps.Controls
 
             // Render initial diff
             Render();
+
+            // Trigger a second render on the UI thread once layout has completed
+            Dispatcher.UIThread.Post(() =>
+            {
+                Console.WriteLine("Post-SetupEditors render");
+                Render();
+            }, DispatcherPriority.Loaded);
         }
 
         public void Render()

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -232,7 +232,16 @@ namespace AzurePrOps.Controls
                 {
                     bool sameColor = fgSolid.Color.ToUInt32() == bgSolid.Color.ToUInt32();
                     Console.WriteLine($"Foreground matches background? {sameColor}");
+                    Console.WriteLine($"OldEditor alpha: {fgSolid.Color.A}, BG alpha: {bgSolid.Color.A}");
                 }
+            }
+            else
+            {
+                Console.WriteLine("Theme brushes missing - using defaults");
+                _oldEditor.Foreground = Brushes.White;
+                _oldEditor.Background = Brushes.Black;
+                _newEditor.Foreground = Brushes.White;
+                _newEditor.Background = Brushes.Black;
             }
 
             // Set explicit height for better visibility
@@ -283,6 +292,9 @@ namespace AzurePrOps.Controls
             Console.WriteLine($"VisualLines valid? old: {_oldEditor.TextArea.TextView.VisualLinesValid}, new: {_newEditor.TextArea.TextView.VisualLinesValid}");
             Console.WriteLine($"OldEditor size: {_oldEditor.Bounds.Width}x{_oldEditor.Bounds.Height}");
             Console.WriteLine($"NewEditor size: {_newEditor.Bounds.Width}x{_newEditor.Bounds.Height}");
+            Console.WriteLine($"Visual line count old: {_oldEditor.TextArea.TextView.VisualLines.Count}, new: {_newEditor.TextArea.TextView.VisualLines.Count}");
+            Console.WriteLine($"OldEditor visible: {_oldEditor.IsVisible}, effective: {_oldEditor.IsEffectivelyVisible}, opacity: {_oldEditor.Opacity}");
+            Console.WriteLine($"NewEditor visible: {_newEditor.IsVisible}, effective: {_newEditor.IsEffectivelyVisible}, opacity: {_newEditor.Opacity}");
             if (_oldEditor.Foreground is ISolidColorBrush oldFg && _oldEditor.Background is ISolidColorBrush oldBg)
                 Console.WriteLine($"OldEditor colors numeric - FG: {oldFg.Color}, BG: {oldBg.Color}");
             if (_newEditor.Foreground is ISolidColorBrush newFg && _newEditor.Background is ISolidColorBrush newBg)

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -281,6 +281,12 @@ namespace AzurePrOps.Controls
             _newEditor.TextArea.TextView.EnsureVisualLines();
             Console.WriteLine($"Editors invalidated for redraw");
             Console.WriteLine($"VisualLines valid? old: {_oldEditor.TextArea.TextView.VisualLinesValid}, new: {_newEditor.TextArea.TextView.VisualLinesValid}");
+            Console.WriteLine($"OldEditor size: {_oldEditor.Bounds.Width}x{_oldEditor.Bounds.Height}");
+            Console.WriteLine($"NewEditor size: {_newEditor.Bounds.Width}x{_newEditor.Bounds.Height}");
+            if (_oldEditor.Foreground is ISolidColorBrush oldFg && _oldEditor.Background is ISolidColorBrush oldBg)
+                Console.WriteLine($"OldEditor colors numeric - FG: {oldFg.Color}, BG: {oldBg.Color}");
+            if (_newEditor.Foreground is ISolidColorBrush newFg && _newEditor.Background is ISolidColorBrush newBg)
+                Console.WriteLine($"NewEditor colors numeric - FG: {newFg.Color}, BG: {newBg.Color}");
 
             Console.WriteLine($"Set document text - Old: {oldTextValue.Length} bytes, New: {newTextValue.Length} bytes");
             Console.WriteLine($"OldEditor.Document length now: {_oldEditor.Document.TextLength}");

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -110,12 +110,14 @@ namespace AzurePrOps.Controls
                 // renders even if the control is created before data is set.
                 OldText = diff.OldText ?? string.Empty;
                 NewText = diff.NewText ?? string.Empty;
+                Console.WriteLine($"DataContext changed to FileDiff: {diff.FilePath}");
             }
             else
             {
                 // Clear content when the DataContext is unset or of the wrong type
                 OldText = string.Empty;
                 NewText = string.Empty;
+                Console.WriteLine("DataContext cleared or invalid");
             }
         }
 
@@ -251,6 +253,13 @@ namespace AzurePrOps.Controls
             // Also set the Text property for consistency
             _oldEditor.Text = oldTextValue;
             _newEditor.Text = newTextValue;
+
+            // Force redraw after setting text to ensure content becomes visible
+            _oldEditor.InvalidateVisual();
+            _newEditor.InvalidateVisual();
+            _oldEditor.TextArea.TextView.InvalidateVisual();
+            _newEditor.TextArea.TextView.InvalidateVisual();
+            Console.WriteLine("Editors invalidated for redraw");
 
             Console.WriteLine($"Set document text - Old: {oldTextValue.Length} bytes, New: {newTextValue.Length} bytes");
             Console.WriteLine($"OldEditor.Document length now: {_oldEditor.Document.TextLength}");
@@ -478,6 +487,11 @@ namespace AzurePrOps.Controls
 
             // Log line counts for debugging
             Console.WriteLine($"DiffViewer stats: {addedLines} added, {removedLines} removed, {modifiedLines} modified");
+
+            // Log first displayed line for extra visibility
+            var firstOld = _oldEditor.Document.Lines.Count > 0 ? _oldEditor.Document.GetText(_oldEditor.Document.Lines.First()) : "<none>";
+            var firstNew = _newEditor.Document.Lines.Count > 0 ? _newEditor.Document.GetText(_newEditor.Document.Lines.First()) : "<none>";
+            Console.WriteLine($"First lines - old: '{firstOld}', new: '{firstNew}'");
 
             if (_addedLinesText != null)
                 _addedLinesText.Text = $"{addedLines} added";

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -207,6 +207,19 @@ namespace AzurePrOps.Controls
             _oldEditor.ShowLineNumbers = true;
             _newEditor.ShowLineNumbers = true;
 
+            // Explicitly set editor foreground/background to match the app theme
+            var fgBrush = (IBrush?)Application.Current?.FindResource("PrimaryBrush");
+            var bgBrush = (IBrush?)Application.Current?.FindResource("CardBackgroundBrush");
+            if (fgBrush != null && bgBrush != null)
+            {
+                _oldEditor.Foreground = fgBrush;
+                _oldEditor.Background = bgBrush;
+                _newEditor.Foreground = fgBrush;
+                _newEditor.Background = bgBrush;
+                Console.WriteLine($"OldEditor colors - FG: {fgBrush}, BG: {bgBrush}");
+                Console.WriteLine($"NewEditor colors - FG: {fgBrush}, BG: {bgBrush}");
+            }
+
             // Set explicit height for better visibility
             _oldEditor.MinHeight = 250;
             _newEditor.MinHeight = 250;
@@ -240,6 +253,8 @@ namespace AzurePrOps.Controls
             _newEditor.Text = newTextValue;
 
             Console.WriteLine($"Set document text - Old: {oldTextValue.Length} bytes, New: {newTextValue.Length} bytes");
+            Console.WriteLine($"OldEditor.Document length now: {_oldEditor.Document.TextLength}");
+            Console.WriteLine($"NewEditor.Document length now: {_newEditor.Document.TextLength}");
 
             // Clear previous transformers
             _oldEditor.TextArea.TextView.LineTransformers.Clear();


### PR DESCRIPTION
## Summary
- set foreground/background on TextEditors to avoid dark-on-dark rendering
- log colors and document length after rendering to aid troubleshooting

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685c6bb22a688320bfdadefdcf10c2ed