### PR TITLE
Refine logging strategy

### DIFF
--- a/AzurePrOps.Logging/AppLogger.cs
+++ b/AzurePrOps.Logging/AppLogger.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Logging;
+
+namespace AzurePrOps.Logging;
+
+public static class AppLogger
+{
+    private static ILoggerFactory _loggerFactory = LoggerFactory.Create(builder =>
+    {
+        builder.SetMinimumLevel(LogLevel.Information);
+        builder.AddConsole(options =>
+        {
+            options.TimestampFormat = "hh:mm:ss ";
+        });
+    });
+
+    public static ILoggerFactory Factory => _loggerFactory;
+
+    public static void Configure(Action<ILoggingBuilder> configure)
+    {
+        _loggerFactory = LoggerFactory.Create(configure);
+    }
+
+    public static ILogger CreateLogger(string categoryName) => _loggerFactory.CreateLogger(categoryName);
+
+    public static ILogger<T> CreateLogger<T>() => _loggerFactory.CreateLogger<T>();
+}

--- a/AzurePrOps.Logging/AzurePrOps.Logging.csproj
+++ b/AzurePrOps.Logging/AzurePrOps.Logging.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
+  </ItemGroup>
+
+</Project>

--- a/AzurePrOps/AzurePrOps.AzureConnection/AzurePrOps.AzureConnection.csproj
+++ b/AzurePrOps/AzurePrOps.AzureConnection/AzurePrOps.AzureConnection.csproj
@@ -7,4 +7,12 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\AzurePrOps.Logging\AzurePrOps.Logging.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/AzurePrOps/AzurePrOps.AzureConnection/Services/AzureDevOpsClient.cs
+++ b/AzurePrOps/AzurePrOps.AzureConnection/Services/AzureDevOpsClient.cs
@@ -3,11 +3,14 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using AzurePrOps.AzureConnection.Models;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using AzurePrOps.Logging;
 
 namespace AzurePrOps.AzureConnection.Services;
 
 public partial class AzureDevOpsClient
 {
+    private static readonly ILogger _logger = AppLogger.CreateLogger<AzureDevOpsClient>();
     private const string AzureDevOpsBaseUrl = "https://dev.azure.com";
     private const string AzureDevOpsVsspsUrl = "https://vssps.dev.azure.com";
     private const string ApiVersion = "7.1";
@@ -106,7 +109,7 @@ public partial class AzureDevOpsClient
                         catch (Exception ex)
                         {
                             // Skip this reviewer if there's an issue with the JSON
-                            Console.WriteLine($"Error processing reviewer: {ex.Message}");
+                            _logger.LogWarning(ex, "Error processing reviewer");
                         }
                     }
                 }
@@ -116,7 +119,7 @@ public partial class AzureDevOpsClient
                             catch (Exception ex)
                             {
                 // Skip this PR if there's an issue with the JSON
-                Console.WriteLine($"Error processing pull request: {ex.Message}");
+                _logger.LogWarning(ex, "Error processing pull request");
                             }
             }
         }

--- a/AzurePrOps/AzurePrOps.ReviewLogic/AzurePrOps.ReviewLogic.csproj
+++ b/AzurePrOps/AzurePrOps.ReviewLogic/AzurePrOps.ReviewLogic.csproj
@@ -12,6 +12,11 @@
       <PackageReference Include="DiffPlex" Version="1.8.0" />
       <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\AzurePrOps.Logging\AzurePrOps.Logging.csproj" />
     </ItemGroup>
 
 </Project>

--- a/AzurePrOps/AzurePrOps.sln
+++ b/AzurePrOps/AzurePrOps.sln
@@ -1,10 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePrOps.AzureConnection", "AzurePrOps.AzureConnection\AzurePrOps.AzureConnection.csproj", "{9BE5282B-BB47-4EF3-8E12-F73E367402E3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePrOps", "AzurePrOps\AzurePrOps.csproj", "{7DE18E50-89FA-4E1B-BBD2-2DD51A27754E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePrOps.ReviewLogic", "AzurePrOps.ReviewLogic\AzurePrOps.ReviewLogic.csproj", "{EE4F6FEC-72EE-43F4-A791-BBB9F46933D4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzurePrOps.Logging", "..\AzurePrOps.Logging\AzurePrOps.Logging.csproj", "{5AB56C2C-8DA7-4C0E-91E7-FE50E89ED50B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +27,9 @@ Global
 		{EE4F6FEC-72EE-43F4-A791-BBB9F46933D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EE4F6FEC-72EE-43F4-A791-BBB9F46933D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EE4F6FEC-72EE-43F4-A791-BBB9F46933D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AB56C2C-8DA7-4C0E-91E7-FE50E89ED50B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AB56C2C-8DA7-4C0E-91E7-FE50E89ED50B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AB56C2C-8DA7-4C0E-91E7-FE50E89ED50B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AB56C2C-8DA7-4C0E-91E7-FE50E89ED50B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/AzurePrOps/AzurePrOps/App.axaml.cs
+++ b/AzurePrOps/AzurePrOps/App.axaml.cs
@@ -7,11 +7,14 @@ using AzurePrOps.Models;
 using ReactiveUI;
 using AzurePrOps.ViewModels;
 using AzurePrOps.Views;
+using Microsoft.Extensions.Logging;
+using AzurePrOps.Logging;
 
 namespace AzurePrOps;
 
 public partial class App : Application
 {
+    private static readonly ILogger _logger = AppLogger.CreateLogger<App>();
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -23,7 +26,7 @@ public partial class App : Application
         RxApp.DefaultExceptionHandler = Observer.Create<Exception>(ex =>
         {
             // Log the exception
-            Console.WriteLine($"Unhandled ReactiveUI exception: {ex}");
+            _logger.LogError(ex, "Unhandled ReactiveUI exception");
 
             // Show error dialog
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)

--- a/AzurePrOps/AzurePrOps/AzurePrOps.csproj
+++ b/AzurePrOps/AzurePrOps/AzurePrOps.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
   <ItemGroup>
-        <Folder Include="Models\"/>
-        <AvaloniaResource Include="Assets\**"/>
-        <AvaloniaResource Include="Styles\**"/>
+        <Folder Include="Models\" />
+        <AvaloniaResource Include="Assets\**" />
+        <AvaloniaResource Include="Styles\**" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,23 +21,25 @@
   <ItemGroup>
     <ProjectReference Include="..\AzurePrOps.AzureConnection\AzurePrOps.AzureConnection.csproj" />
     <ProjectReference Include="..\AzurePrOps.ReviewLogic\AzurePrOps.ReviewLogic.csproj" />
+    <ProjectReference Include="..\..\AzurePrOps.Logging\AzurePrOps.Logging.csproj" />
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.7"/>
+        <PackageReference Include="Avalonia" Version="11.2.7" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.7"/>
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.7"/>
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.7"/>
+        <PackageReference Include="Avalonia.Desktop" Version="11.2.7" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.7" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.7" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia.Diagnostics" Version="11.2.7">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.7"/>
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.7" />
         <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0" />
-        <PackageReference Include="DiffPlex" Version="1.8.0"/>
+        <PackageReference Include="DiffPlex" Version="1.8.0" />
         <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
     </ItemGroup>
 </Project>

--- a/AzurePrOps/AzurePrOps/Program.cs
+++ b/AzurePrOps/AzurePrOps/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.ReactiveUI;
 using System;
+using AzurePrOps.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace AzurePrOps;
 
@@ -10,8 +12,11 @@ sealed class Program
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        AppLogger.Configure(builder => builder.AddConsole());
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()

--- a/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
@@ -12,11 +12,14 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using AzurePrOps.Views;
+using Microsoft.Extensions.Logging;
+using AzurePrOps.Logging;
 
 namespace AzurePrOps.ViewModels;
 
 public class MainWindowViewModel : ViewModelBase
 {
+    private static readonly ILogger _logger = AppLogger.CreateLogger<MainWindowViewModel>();
     private readonly AzureDevOpsClient _client = new();
     private readonly IPullRequestService _pullRequestService;
     private readonly Models.ConnectionSettings _settings;
@@ -261,19 +264,17 @@ public class MainWindowViewModel : ViewModelBase
                     null);
 
                 // Log information about the diffs
-                Console.WriteLine($"Retrieved {diffs.Count} diffs for PR #{SelectedPullRequest.Id}");
+                _logger.LogDebug("Retrieved {Count} diffs for PR #{Id}", diffs.Count, SelectedPullRequest.Id);
                 foreach (var diff in diffs)
                 {
-                    Console.WriteLine($"  - {diff.FilePath}: OldText={diff.OldText?.Length ?? 0} bytes, NewText={diff.NewText?.Length ?? 0} bytes, Diff={diff.Diff?.Length ?? 0} bytes");
-                    Console.WriteLine(diff.OldText);
-                    Console.WriteLine(diff.NewText);
+                    _logger.LogDebug("  - {Path}: OldText={Old} bytes, NewText={New} bytes, Diff={Diff} bytes", diff.FilePath, diff.OldText?.Length ?? 0, diff.NewText?.Length ?? 0, diff.Diff?.Length ?? 0);
                 }
 
                 // Always show the window, even if we couldn't get diffs
                 Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     var vm = new PullRequestDetailsWindowViewModel(SelectedPullRequest, Comments, diffs);
-                    Console.WriteLine($"Created ViewModel with {vm.FileDiffs.Count} FileDiffs");
+                    _logger.LogDebug("Created ViewModel with {Count} FileDiffs", vm.FileDiffs.Count);
                     var window = new PullRequestDetailsWindow { DataContext = vm };
                     window.Show();
                 });

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml.cs
@@ -5,11 +5,14 @@ using Avalonia.Controls.Templates;
 using AzurePrOps.Controls;
 using AzurePrOps.ViewModels;
 using AzurePrOps.ReviewLogic.Models;
+using Microsoft.Extensions.Logging;
+using AzurePrOps.Logging;
 
 namespace AzurePrOps.Views;
 
 public partial class PullRequestDetailsWindow : Window
 {
+    private static readonly ILogger _logger = AppLogger.CreateLogger<PullRequestDetailsWindow>();
     public PullRequestDetailsWindow()
     {
         InitializeComponent();
@@ -19,19 +22,20 @@ public partial class PullRequestDetailsWindow : Window
         {
             if (DataContext is PullRequestDetailsWindowViewModel viewModel)
             {
-                Console.WriteLine($"PR Details Window loaded with {viewModel.FileDiffs.Count} file diffs");
+                _logger.LogInformation("PR Details Window loaded with {Count} file diffs", viewModel.FileDiffs.Count);
                 foreach (var diff in viewModel.FileDiffs)
                 {
-                    Console.WriteLine($"FileDiff: {diff.FilePath}");
-                    Console.WriteLine($"  OldText Length: {diff.OldText?.Length ?? 0}");
-                    Console.WriteLine($"  NewText Length: {diff.NewText?.Length ?? 0}");
-                    Console.WriteLine($"  Diff Length: {diff.Diff?.Length ?? 0}");
-                    Console.WriteLine($"  HasDiff: {!string.IsNullOrEmpty(diff.Diff)}");
+                    _logger.LogDebug("FileDiff: {Path} - OldText {OldLength} bytes, NewText {NewLength} bytes, Diff {DiffLength} bytes, HasDiff {HasDiff}",
+                        diff.FilePath,
+                        diff.OldText?.Length ?? 0,
+                        diff.NewText?.Length ?? 0,
+                        diff.Diff?.Length ?? 0,
+                        !string.IsNullOrEmpty(diff.Diff));
                 }
             }
             else
             {
-                Console.WriteLine("PR Details Window loaded with NULL or invalid DataContext");
+                _logger.LogWarning("PR Details Window loaded with NULL or invalid DataContext");
             }
         };
     }


### PR DESCRIPTION
## Summary
- centralize logger factory with accessible property
- downgrade noisy info logs to debug and keep essential warnings
- ensure single informative log on PR detail load

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`
- `dotnet test AzurePrOps/AzurePrOps.sln`

------
https://chatgpt.com/codex/tasks/task_e_6862bf6adb048320b66e8292a4c7b92d