### PR TITLE
Add external editor selection

### DIFF
--- a/AzurePrOps/AzurePrOps.ReviewLogic/Services/IDEIntegrationService.cs
+++ b/AzurePrOps/AzurePrOps.ReviewLogic/Services/IDEIntegrationService.cs
@@ -4,11 +4,18 @@ namespace AzurePrOps.ReviewLogic.Services;
 
 public class IDEIntegrationService : IIDEIntegrationService
 {
+    private readonly string _editorCommand;
+
+    public IDEIntegrationService(string editorCommand)
+    {
+        _editorCommand = editorCommand;
+    }
+
     public void OpenInIDE(string filePath, int lineNumber)
     {
         Process.Start(new ProcessStartInfo
         {
-            FileName        = "code",
+            FileName        = _editorCommand,
             Arguments       = $"-g \"{filePath}\":{lineNumber}",
             UseShellExecute = true
         });

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -16,6 +16,7 @@ using Avalonia.VisualTree;
 using Avalonia.Input;
 using AzurePrOps.ReviewLogic.Models;
 using AzurePrOps.ReviewLogic.Services;
+using AzurePrOps.Models;
 using DiffPlex;
 using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
@@ -107,7 +108,10 @@ namespace AzurePrOps.Controls
             PatchService       = new FilePatchService();
             FoldingService     = new IndentationFoldingService();
             SearchService      = new SimpleSearchService();
-            IDEService         = new IDEIntegrationService();
+            string editor = ConnectionSettingsStorage.TryLoad(out var s)
+                ? s!.EditorCommand
+                : EditorDetector.GetDefaultEditor();
+            IDEService = new IDEIntegrationService(editor);
 
             InitializeComponent();
             Loaded += (_, __) => SetupEditors();

--- a/AzurePrOps/AzurePrOps/Models/ConnectionSettings.cs
+++ b/AzurePrOps/AzurePrOps/Models/ConnectionSettings.cs
@@ -6,4 +6,5 @@ public record ConnectionSettings(
     string Repository,
     string PersonalAccessToken,
     string ReviewerId,
+    string EditorCommand = "code",
     bool UseGitDiff = false);

--- a/AzurePrOps/AzurePrOps/Models/EditorDetector.cs
+++ b/AzurePrOps/AzurePrOps/Models/EditorDetector.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace AzurePrOps.Models;
+
+public static class EditorDetector
+{
+    private static readonly string[] CandidateCommands = new[]
+    {
+        // Common editors
+        "code",            // Visual Studio Code
+        "code-insiders",   // VS Code Insiders
+        "rider",           // JetBrains Rider
+        "rider64",
+        "subl",            // Sublime Text
+        "notepad++",
+        "notepad",
+        "gedit",
+        "vim",
+        "vi",
+        "nano",
+        "emacs",
+
+        // JetBrains IDEs
+        "idea",            // IntelliJ IDEA
+        "idea64",
+
+        // Android Studio
+        "studio",          // linux/mac script name
+        "studio64",
+
+        // Visual Studio (Windows)
+        "devenv"          // Visual Studio IDE
+    };
+
+    public static IReadOnlyList<string> GetAvailableEditors()
+    {
+        var result = new List<string>();
+        foreach (var cmd in CandidateCommands)
+        {
+            if (IsCommandAvailable(cmd))
+                result.Add(cmd);
+        }
+        return result;
+    }
+
+    public static string GetDefaultEditor() => GetAvailableEditors().FirstOrDefault() ?? "code";
+
+    private static bool IsCommandAvailable(string command)
+    {
+        var paths = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var p in paths)
+        {
+            var full = Path.Combine(p, command);
+            if (OperatingSystem.IsWindows())
+            {
+                if (File.Exists(full) || File.Exists(full + ".exe"))
+                    return true;
+            }
+            else if (File.Exists(full))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/AzurePrOps/AzurePrOps/ViewModels/LoginWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/LoginWindowViewModel.cs
@@ -82,6 +82,7 @@ public class LoginWindowViewModel : ViewModelBase
                     Repository: "",
                     PersonalAccessToken: PersonalAccessToken,
                     ReviewerId: reviewerId,
+                    EditorCommand: EditorDetector.GetDefaultEditor(),
                     UseGitDiff: false));
 
                 var loginInfo = new LoginInfo(reviewerId, PersonalAccessToken);

--- a/AzurePrOps/AzurePrOps/ViewModels/ProjectSelectionWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/ProjectSelectionWindowViewModel.cs
@@ -72,6 +72,7 @@ public class ProjectSelectionWindowViewModel : ViewModelBase
                 SelectedRepository?.Id ?? string.Empty,
                 _personalAccessToken,
                 _reviewerId,
+                EditorDetector.GetDefaultEditor(),
                 UseGitDiff: false);
             ConnectionSettingsStorage.Save(settings);
             ConnectionSettings = settings;

--- a/AzurePrOps/AzurePrOps/ViewModels/SettingsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/SettingsWindowViewModel.cs
@@ -68,12 +68,26 @@ public class SettingsWindowViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _useGitDiff, value);
     }
 
+    public ObservableCollection<string> Editors { get; } = new();
+
+    private string _selectedEditor = string.Empty;
+    public string SelectedEditor
+    {
+        get => _selectedEditor;
+        set => this.RaiseAndSetIfChanged(ref _selectedEditor, value);
+    }
+
     public SettingsWindowViewModel(ConnectionSettings currentSettings)
     {
         _initialSettings = currentSettings;
         _personalAccessToken = currentSettings.PersonalAccessToken;
         _reviewerId = currentSettings.ReviewerId;
         _useGitDiff = currentSettings.UseGitDiff;
+        foreach (var e in EditorDetector.GetAvailableEditors())
+            Editors.Add(e);
+        _selectedEditor = string.IsNullOrWhiteSpace(currentSettings.EditorCommand)
+            ? EditorDetector.GetDefaultEditor()
+            : currentSettings.EditorCommand;
 
         SaveCommand = ReactiveCommand.Create(() =>
         {
@@ -83,6 +97,7 @@ public class SettingsWindowViewModel : ViewModelBase
                 SelectedRepository?.Id ?? string.Empty,
                 _personalAccessToken,
                 _reviewerId,
+                SelectedEditor,
                 UseGitDiff);
             ConnectionSettingsStorage.Save(settings);
             ConnectionSettings = settings;

--- a/AzurePrOps/AzurePrOps/Views/SettingsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/SettingsWindow.axaml
@@ -12,7 +12,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="using:AzurePrOps.ViewModels"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Margin="20" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
+    <Grid Margin="20" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
         <TextBlock
             FontSize="18"
             FontWeight="Bold"
@@ -136,7 +136,18 @@
             Content="Use Git client for diffs"
             IsChecked="{Binding UseGitDiff}" />
 
-        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+        <StackPanel Grid.Row="6" Margin="0,0,0,10">
+            <TextBlock
+                FontWeight="SemiBold"
+                Margin="0,0,0,5"
+                Text="External Editor" />
+            <ComboBox
+                ItemsSource="{Binding Editors}"
+                SelectedItem="{Binding SelectedEditor}"
+                Width="200" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
             <Button
                 Content="Logout"
                 Command="{Binding LogoutCommand}"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 A minimal Avalonia UI tool for interacting with Azure DevOps pull requests.
 
 Upon launch, the application now prompts for your organization, project, repository, reviewer id and personal access token (PAT). These values are stored only for the current session and remove the need to edit the source code when connecting to different projects.
+
+The settings window also lets you choose which external editor to open files with. Available options are detected based on the editors found on your system.


### PR DESCRIPTION
## Summary
- detect installed editors
- store the editor command in `ConnectionSettings`
- allow configuring external editor in settings window
- open diffs using the chosen editor
- document editor selection feature
- expand editor detection to include Visual Studio, Android Studio, IntelliJ IDEA and more

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686440a87864832097f6e0d0789828b3