### PR TITLE
Fix IDE open command

### DIFF
--- a/AzurePrOps/AzurePrOps.ReviewLogic/Services/IDEIntegrationService.cs
+++ b/AzurePrOps/AzurePrOps.ReviewLogic/Services/IDEIntegrationService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.IO;
 
 namespace AzurePrOps.ReviewLogic.Services;
 
@@ -13,11 +14,29 @@ public class IDEIntegrationService : IIDEIntegrationService
 
     public void OpenInIDE(string filePath, int lineNumber)
     {
+        var args = GetArguments(_editorCommand, filePath, lineNumber);
+
         Process.Start(new ProcessStartInfo
         {
             FileName        = _editorCommand,
-            Arguments       = $"-g \"{filePath}\":{lineNumber}",
-            UseShellExecute = true
+            Arguments       = args,
+            UseShellExecute = false
         });
+    }
+
+    private static string GetArguments(string editor, string filePath, int line)
+    {
+        string cmd = Path.GetFileNameWithoutExtension(editor).ToLowerInvariant();
+
+        return cmd switch
+        {
+            "code" or "code-insiders" => $"-g \"{filePath}\":{line}",
+            "subl"                  => $"\"{filePath}\":{line}",
+            "rider" or "rider64" or "idea" or "idea64" or "studio" or "studio64" => $"\"{filePath}\" --line {line}",
+            "notepad++"             => $"-n{line} \"{filePath}\"",
+            "gedit" or "vim" or "vi" or "nano" or "emacs" => $"+{line} \"{filePath}\"",
+            "devenv"               => $"/Edit \"{filePath}\" /Command \"Edit.Goto {line}\"",
+            _                       => $"\"{filePath}\""
+        };
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ A minimal Avalonia UI tool for interacting with Azure DevOps pull requests.
 Upon launch, the application now prompts for your organization, project, repository, reviewer id and personal access token (PAT). These values are stored only for the current session and remove the need to edit the source code when connecting to different projects.
 
 The settings window also lets you choose which external editor to open files with. Available options are detected based on the editors found on your system.
+
+Make sure your chosen editor is available on the system `PATH`. The application
+launches the editor using its command name (e.g. `code` for Visual Studio Code),
+so the command must be discoverable without specifying a full path.
+
+Opening files works across Linux and Windows for many popular IDEs such as
+VS Code, JetBrains Rider, Sublime Text and Notepad++. The launch arguments are
+adjusted automatically for each supported editor so that the specified line
+number is focused when possible.


### PR DESCRIPTION
## Summary
- support multiple editors with custom line arguments
- update docs on cross-platform editor launching

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6864466097308320a83f5bbee416fe0f