### PR TITLE
Enable double-click for PR details

### DIFF
--- a/AzurePrOps/AzurePrOps/Views/MainWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/MainWindow.axaml
@@ -55,7 +55,10 @@
             <TextBox Width="120" Watermark="View Name" Text="{Binding NewViewName}"/>
             <Button Content="Save" Command="{Binding SaveViewCommand}" Width="60"/>
             </StackPanel>
-            <ListBox Grid.Row="3" ItemsSource="{Binding PullRequests}" SelectedItem="{Binding SelectedPullRequest}">
+            <ListBox Grid.Row="3"
+                     ItemsSource="{Binding PullRequests}"
+                     SelectedItem="{Binding SelectedPullRequest}"
+                     DoubleTapped="PullRequests_DoubleTapped">
             <ListBox.ItemTemplate>
                 <DataTemplate>
                     <Border Padding="4"

--- a/AzurePrOps/AzurePrOps/Views/MainWindow.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Views/MainWindow.axaml.cs
@@ -1,6 +1,8 @@
 using System;
+using Avalonia.Interactivity;
 using Avalonia.Controls;
 using AzurePrOps.ViewModels;
+using AzurePrOps.AzureConnection.Models;
 
 namespace AzurePrOps.Views;
 
@@ -18,5 +20,18 @@ public partial class MainWindow : Window
         {
             vm.RefreshCommand.Execute().Subscribe();
         }
+    }
+
+    private void PullRequests_DoubleTapped(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm)
+            return;
+
+        if (sender is ListBox listBox && listBox.SelectedItem is PullRequestInfo pr)
+        {
+            vm.SelectedPullRequest = pr;
+        }
+
+        vm.ViewDetailsCommand.Execute().Subscribe();
     }
 }


### PR DESCRIPTION
## Summary
- allow double-tapping list items to open the pull request details view

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_688260f07704832086647d891f4db5cb