### PR TITLE
Add comments window and command

### DIFF
--- a/AzurePrOps/AzurePrOps/App.axaml
+++ b/AzurePrOps/AzurePrOps/App.axaml
@@ -17,6 +17,7 @@
         <converters:StatusToIconConverter x:Key="StatusToIcon" />
         <converters:VoteToIconConverter x:Key="VoteToIcon" />
         <converters:StringNotEmptyConverter x:Key="StringNotEmptyConverter" />
+        <converters:CollectionNotEmptyConverter x:Key="CollectionNotEmptyConverter" />
     </Application.Resources>
 
     <Application.Styles>

--- a/AzurePrOps/AzurePrOps/Converters/CollectionNotEmptyConverter.cs
+++ b/AzurePrOps/AzurePrOps/Converters/CollectionNotEmptyConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace AzurePrOps.Converters;
+
+public class CollectionNotEmptyConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        bool hasItems = false;
+        if (value is IEnumerable enumerable)
+        {
+            foreach (var _ in enumerable)
+            {
+                hasItems = true;
+                break;
+            }
+        }
+
+        if (parameter is string p && p.Equals("invert", StringComparison.OrdinalIgnoreCase))
+            return !hasItems;
+
+        return hasItems;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/AzurePrOps/AzurePrOps/ViewModels/CommentsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/CommentsWindowViewModel.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+using AzurePrOps.AzureConnection.Models;
+using ReactiveUI;
+
+namespace AzurePrOps.ViewModels;
+
+public class CommentsWindowViewModel : ViewModelBase
+{
+    public string Title { get; }
+    public ObservableCollection<PullRequestComment> Comments { get; }
+    public ReactiveCommand<Unit, Unit> CloseCommand { get; }
+
+    public CommentsWindowViewModel(string title, IEnumerable<PullRequestComment> comments)
+    {
+        Title = title;
+        Comments = new ObservableCollection<PullRequestComment>(
+            comments.OrderByDescending(c => c.PostedDate));
+        CloseCommand = ReactiveCommand.Create(() => { });
+    }
+}

--- a/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
@@ -24,6 +24,7 @@ public class PullRequestDetailsWindowViewModel : ViewModelBase
 
     public ReactiveCommand<Unit, Unit> OpenInBrowserCommand { get; }
     public ReactiveCommand<Unit, Unit> ShowInsightsCommand { get; }
+    public ReactiveCommand<Unit, Unit> ShowCommentsCommand { get; }
 
     public ObservableCollection<ReviewModels.FileDiff> FileDiffs { get; } = new();
 
@@ -217,6 +218,14 @@ public class PullRequestDetailsWindowViewModel : ViewModelBase
                 // Swallow exceptions to avoid crashing the app
                 _logger.LogWarning(ex, "Failed to open browser");
             }
+        });
+
+        ShowCommentsCommand = ReactiveCommand.Create(() =>
+        {
+            string title = $"Comments for PR #{PullRequest.Id}";
+            var vm = new CommentsWindowViewModel(title, Comments);
+            var window = new CommentsWindow { DataContext = vm };
+            window.Show();
         });
 
         ShowInsightsCommand = ReactiveCommand.Create(() =>

--- a/AzurePrOps/AzurePrOps/Views/CommentsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/CommentsWindow.axaml
@@ -1,0 +1,60 @@
+<Window
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="using:AzurePrOps.ViewModels"
+    xmlns:model="using:AzurePrOps.AzureConnection.Models"
+    x:Class="AzurePrOps.Views.CommentsWindow"
+    x:DataType="vm:CommentsWindowViewModel"
+    mc:Ignorable="d"
+    Title="{Binding Title}"
+    Width="400"
+    Height="500"
+    WindowStartupLocation="CenterOwner">
+    <Design.DataContext>
+        <vm:CommentsWindowViewModel Title="Comments">
+            <vm:CommentsWindowViewModel.Comments>
+                <model:PullRequestComment Author="Jane" Content="Looks good" PostedDate="2024-01-01" />
+            </vm:CommentsWindowViewModel.Comments>
+        </vm:CommentsWindowViewModel>
+    </Design.DataContext>
+    <StackPanel Margin="20" Spacing="12">
+        <TextBlock Text="{Binding Title}" FontSize="20" FontWeight="Bold" />
+        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                      IsVisible="{Binding Comments, Converter={StaticResource CollectionNotEmptyConverter}}">
+            <ItemsControl ItemsSource="{Binding Comments}" Margin="0,0,0,8">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="model:PullRequestComment">
+                        <Border
+                            Background="{StaticResource CardBackgroundBrush}"
+                            CornerRadius="6"
+                            Margin="0,0,0,8"
+                            Padding="10,8">
+                            <StackPanel Spacing="4">
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Grid.Column="0"
+                                               FontSize="12"
+                                               FontWeight="SemiBold"
+                                               Text="{Binding Author}" />
+                                    <TextBlock Grid.Column="1"
+                                               FontSize="10"
+                                               Foreground="{StaticResource MutedBrush}"
+                                               Text="{Binding PostedDate}" />
+                                </Grid>
+                                <TextBlock FontSize="12"
+                                           Text="{Binding Content}"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+        <TextBlock Text="No comments found"
+                   Foreground="{StaticResource MutedBrush}"
+                   HorizontalAlignment="Center"
+                   IsVisible="{Binding Comments, Converter={StaticResource CollectionNotEmptyConverter}, ConverterParameter=invert}" />
+        <Button Classes="PrimaryButton" Content="Close" Command="{Binding CloseCommand}" HorizontalAlignment="Right" Width="100" />
+    </StackPanel>
+</Window>

--- a/AzurePrOps/AzurePrOps/Views/CommentsWindow.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Views/CommentsWindow.axaml.cs
@@ -1,0 +1,24 @@
+using System;
+using Avalonia.Controls;
+using AzurePrOps.ViewModels;
+using System.Reactive.Linq;
+
+namespace AzurePrOps.Views;
+
+public partial class CommentsWindow : Window
+{
+    public CommentsWindow()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        base.OnDataContextChanged(e);
+
+        if (DataContext is CommentsWindowViewModel vm)
+        {
+            vm.CloseCommand.Subscribe(_ => Close());
+        }
+    }
+}

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
@@ -120,6 +120,7 @@
                     <Button
                         Classes="SecondaryButton"
                         Content="💬 Comments"
+                        Command="{Binding ShowCommentsCommand}"
                         ToolTip.Tip="View Comments" />
                     <Button
                         Classes="SecondaryButton"


### PR DESCRIPTION
## Summary
- allow viewing all comments from pull request details window
- create `CommentsWindow` and `CommentsWindowViewModel`
- add `ShowCommentsCommand` to pull request details view model
- bind comments button to the new command
- show a friendly message when there are no comments
- sort comments by date and match PR detail styling

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -clp:ErrorsOnly`


------
https://chatgpt.com/codex/tasks/task_e_68849b52ab0483209aa3fd8089840c0b