### PR TITLE
Enable refreshing pull request diffs

### DIFF
--- a/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
@@ -306,7 +306,12 @@ public class MainWindowViewModel : ViewModelBase
                 // Always show the window, even if we couldn't get diffs
                 _ = Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    var vm = new PullRequestDetailsWindowViewModel(SelectedPullRequest, Comments, diffs);
+                    var vm = new PullRequestDetailsWindowViewModel(
+                        SelectedPullRequest,
+                        _pullRequestService,
+                        _settings,
+                        Comments,
+                        diffs);
                     _logger.LogDebug("Created ViewModel with {Count} FileDiffs", vm.FileDiffs.Count);
                     var window = new PullRequestDetailsWindow { DataContext = vm };
                     window.Show();

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
@@ -330,6 +330,7 @@
                                 <Button
                                     Classes="SecondaryButton"
                                     Content="🔄 Refresh"
+                                    Command="{Binding RefreshDiffsCommand}"
                                     ToolTip.Tip="Refresh Diff" />
                             </StackPanel>
                         </Grid>


### PR DESCRIPTION
## Summary
- extend `PullRequestDetailsWindowViewModel` to accept a pull request service and connection settings
- add `RefreshDiffsCommand` and hook it to re-fetch diffs
- wire the Refresh button to the command

## Testing
- `dotnet restore AzurePrOps/AzurePrOps.sln`
- `dotnet build AzurePrOps/AzurePrOps.sln`

------
https://chatgpt.com/codex/tasks/task_e_6884c5ea58fc8320bd64947ee4510d15