### PR TITLE
Add inline comments feature flag

### DIFF
--- a/AzurePrOps/AzurePrOps/App.axaml.cs
+++ b/AzurePrOps/AzurePrOps/App.axaml.cs
@@ -44,6 +44,9 @@ public partial class App : Application
             }
         });
 
+        // Load feature flags so they are available throughout the app
+        FeatureFlagManager.Load();
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             if (ConnectionSettingsStorage.TryLoad(out var loaded))

--- a/AzurePrOps/AzurePrOps/Models/FeatureFlagManager.cs
+++ b/AzurePrOps/AzurePrOps/Models/FeatureFlagManager.cs
@@ -1,0 +1,28 @@
+namespace AzurePrOps.Models;
+
+/// <summary>
+/// Provides application-wide access to feature flags.
+/// </summary>
+public static class FeatureFlagManager
+{
+    private static bool _inlineCommentsEnabled;
+
+    public static bool InlineCommentsEnabled
+    {
+        get => _inlineCommentsEnabled;
+        set
+        {
+            if (_inlineCommentsEnabled != value)
+            {
+                _inlineCommentsEnabled = value;
+                FeatureFlagStorage.Save(new FeatureFlags(_inlineCommentsEnabled));
+            }
+        }
+    }
+
+    public static void Load()
+    {
+        var flags = FeatureFlagStorage.Load();
+        _inlineCommentsEnabled = flags.InlineCommentsEnabled;
+    }
+}

--- a/AzurePrOps/AzurePrOps/Models/FeatureFlagStorage.cs
+++ b/AzurePrOps/AzurePrOps/Models/FeatureFlagStorage.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace AzurePrOps.Models;
+
+/// <summary>
+/// Handles persistence of feature flags to disk.
+/// </summary>
+public static class FeatureFlagStorage
+{
+    private static readonly string FilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "AzurePrOps",
+        "featureflags.json");
+
+    public static FeatureFlags Load()
+    {
+        try
+        {
+            if (!File.Exists(FilePath))
+                return new FeatureFlags(false);
+
+            var json = File.ReadAllText(FilePath);
+            var data = JsonSerializer.Deserialize<FeatureFlags>(json);
+            return data ?? new FeatureFlags(false);
+        }
+        catch
+        {
+            return new FeatureFlags(false);
+        }
+    }
+
+    public static void Save(FeatureFlags flags)
+    {
+        var dir = Path.GetDirectoryName(FilePath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
+
+        var json = JsonSerializer.Serialize(flags);
+        File.WriteAllText(FilePath, json);
+    }
+}

--- a/AzurePrOps/AzurePrOps/Models/FeatureFlags.cs
+++ b/AzurePrOps/AzurePrOps/Models/FeatureFlags.cs
@@ -1,0 +1,6 @@
+namespace AzurePrOps.Models;
+
+/// <summary>
+/// Simple feature flags that can be persisted.
+/// </summary>
+public record FeatureFlags(bool InlineCommentsEnabled);

--- a/AzurePrOps/AzurePrOps/ViewModels/SettingsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/SettingsWindowViewModel.cs
@@ -68,6 +68,13 @@ public class SettingsWindowViewModel : ViewModelBase
         set => this.RaiseAndSetIfChanged(ref _useGitDiff, value);
     }
 
+    private bool _inlineCommentsEnabled = FeatureFlagManager.InlineCommentsEnabled;
+    public bool InlineCommentsEnabled
+    {
+        get => _inlineCommentsEnabled;
+        set => this.RaiseAndSetIfChanged(ref _inlineCommentsEnabled, value);
+    }
+
     public ObservableCollection<string> Editors { get; } = new();
 
     private string _selectedEditor = string.Empty;
@@ -100,6 +107,7 @@ public class SettingsWindowViewModel : ViewModelBase
                 SelectedEditor,
                 UseGitDiff);
             ConnectionSettingsStorage.Save(settings);
+            FeatureFlagManager.InlineCommentsEnabled = InlineCommentsEnabled;
             ConnectionSettings = settings;
 
             if (Avalonia.Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)

--- a/AzurePrOps/AzurePrOps/Views/SettingsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/SettingsWindow.axaml
@@ -12,7 +12,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="using:AzurePrOps.ViewModels"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <Grid Margin="20" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
+    <Grid Margin="20" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
         <TextBlock
             FontSize="18"
             FontWeight="Bold"
@@ -136,7 +136,13 @@
             Content="Use Git client for diffs"
             IsChecked="{Binding UseGitDiff}" />
 
-        <StackPanel Grid.Row="6" Margin="0,0,0,10">
+        <CheckBox
+            Grid.Row="6"
+            Margin="0,0,0,10"
+            Content="Enable inline comments"
+            IsChecked="{Binding InlineCommentsEnabled}" />
+
+        <StackPanel Grid.Row="7" Margin="0,0,0,10">
             <TextBlock
                 FontWeight="SemiBold"
                 Margin="0,0,0,5"
@@ -147,7 +153,7 @@
                 Width="200" />
         </StackPanel>
 
-        <StackPanel Grid.Row="8" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+        <StackPanel Grid.Row="9" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
             <Button
                 Classes="SecondaryButton"
                 Content="Logout"


### PR DESCRIPTION
## Summary
- add `FeatureFlags` record and storage helpers
- expose feature flag values through `FeatureFlagManager`
- load feature flags in `App` startup
- allow toggling inline comments via Settings window

## Testing
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`
- `dotnet test AzurePrOps/AzurePrOps.sln`

------
https://chatgpt.com/codex/tasks/task_e_6884d5888e0c83208992ae0af8fdb8b3