### PR TITLE
Add sidebar for unresolved threads

### DIFF
--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -931,6 +931,14 @@ namespace AzurePrOps.Controls
             }, null, 1500, System.Threading.Timeout.Infinite);
         }
 
+        public void JumpToLine(int lineNumber)
+        {
+            if (_oldEditor != null)
+                ScrollToLine(_oldEditor, lineNumber);
+            if (_newEditor != null && ViewMode == DiffViewMode.SideBySide)
+                ScrollToLine(_newEditor, lineNumber);
+        }
+
         private void SetupScrollSync()
         {
             _oldEditor?.ApplyTemplate();

--- a/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/MainWindowViewModel.cs
@@ -311,7 +311,8 @@ public class MainWindowViewModel : ViewModelBase
                         _pullRequestService,
                         _settings,
                         Comments,
-                        diffs);
+                        diffs,
+                        new CommentsService(_client));
                     _logger.LogDebug("Created ViewModel with {Count} FileDiffs", vm.FileDiffs.Count);
                     var window = new PullRequestDetailsWindow { DataContext = vm };
                     window.Show();

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
@@ -236,6 +236,33 @@
                         </StackPanel>
                     </Border>
 
+                    <!--  Comment Threads  -->
+                    <Border Classes="Card">
+                        <StackPanel Spacing="12">
+                            <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                <TextBlock
+                                    FontSize="16"
+                                    FontWeight="SemiBold"
+                                    Text="🧵 Threads" />
+                                <CheckBox
+                                    Content="Unresolved only"
+                                    IsChecked="{Binding ShowUnresolvedOnly}" />
+                            </StackPanel>
+                            <ScrollViewer MaxHeight="200" VerticalScrollBarVisibility="Auto">
+                                <ListBox Items="{Binding FilteredThreads}" SelectionChanged="ThreadSelectionChanged">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate x:DataType="review:CommentThread">
+                                            <StackPanel Spacing="2">
+                                                <TextBlock FontSize="12" FontWeight="SemiBold" Text="{Binding FilePath}" />
+                                                <TextBlock FontSize="11" Foreground="{StaticResource MutedBrush}" Text="Line {Binding LineNumber}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </ScrollViewer>
+                        </StackPanel>
+                    </Border>
+
                     <!--  File Tree  -->
                     <Border Classes="Card">
                         <StackPanel Spacing="12">
@@ -405,7 +432,8 @@
                                                     OldText="{Binding OldText}"
                                                     PullRequestId="{Binding DataContext.PullRequest.Id, RelativeSource={RelativeSource AncestorType=Window}}"
                                                     VerticalAlignment="Stretch"
-                                                    ViewMode="SideBySide" />
+                                                    ViewMode="SideBySide"
+                                                    Loaded="DiffViewer_Loaded" />
                                             </Border>
 
                                         </Expander>

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml.cs
@@ -7,12 +7,15 @@ using AzurePrOps.ViewModels;
 using AzurePrOps.ReviewLogic.Models;
 using Microsoft.Extensions.Logging;
 using AzurePrOps.Logging;
+using System.Collections.Generic;
+using Avalonia.VisualTree;
 
 namespace AzurePrOps.Views;
 
 public partial class PullRequestDetailsWindow : Window
 {
     private static readonly ILogger _logger = AppLogger.CreateLogger<PullRequestDetailsWindow>();
+    private readonly Dictionary<string, DiffViewer> _diffViewerMap = new();
     public PullRequestDetailsWindow()
     {
         InitializeComponent();
@@ -38,6 +41,30 @@ public partial class PullRequestDetailsWindow : Window
                 _logger.LogWarning("PR Details Window loaded with NULL or invalid DataContext");
             }
         };
+    }
+
+    private void DiffViewer_Loaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (sender is DiffViewer dv && dv.DataContext is FileDiff diff)
+        {
+            _diffViewerMap[diff.FilePath] = dv;
+        }
+    }
+
+    private void ThreadSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (e.AddedItems.Count == 0 || e.AddedItems[0] is not CommentThread thread)
+            return;
+
+        if (_diffViewerMap.TryGetValue(thread.FilePath, out var viewer))
+        {
+            var expander = viewer.FindAncestorOfType<Expander>();
+            if (expander != null)
+                expander.IsExpanded = true;
+
+            viewer.BringIntoView();
+            viewer.JumpToLine(thread.LineNumber);
+        }
     }
 
     // The DiffViewer now updates itself when its DataContext changes,


### PR DESCRIPTION
## Summary
- show unresolved threads in `PullRequestDetailsWindow`
- register DiffViewers for navigation
- navigate to diff line when selecting a thread
- load threads from `CommentsService`

## Testing
- `dotnet test AzurePrOps/AzurePrOps.Tests/AzurePrOps.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6884f2844db88320866e47d79983b304