### PR TITLE
Add PR management methods to devops interface

### DIFF
--- a/AzurePrOps/AzurePrOps.AzureConnection/Services/AzureDevOpsClient.cs
+++ b/AzurePrOps/AzurePrOps.AzureConnection/Services/AzureDevOpsClient.cs
@@ -616,4 +616,30 @@ public partial class AzureDevOpsClient : IAzureDevOpsClient
         -10 => "Rejected",
         _ => "No vote"
     };
+
+    public Task SetPullRequestDraftAsync(
+        string organization,
+        string project,
+        string repositoryId,
+        int pullRequestId,
+        bool isDraft,
+        string personalAccessToken) =>
+        Task.CompletedTask;
+
+    public Task CompletePullRequestAsync(
+        string organization,
+        string project,
+        string repositoryId,
+        int pullRequestId,
+        AzurePrOps.ReviewLogic.Models.MergeOptions mergeOptions,
+        string personalAccessToken) =>
+        Task.CompletedTask;
+
+    public Task AbandonPullRequestAsync(
+        string organization,
+        string project,
+        string repositoryId,
+        int pullRequestId,
+        string personalAccessToken) =>
+        Task.CompletedTask;
 }

--- a/AzurePrOps/AzurePrOps.ReviewLogic/Models/MergeOptions.cs
+++ b/AzurePrOps/AzurePrOps.ReviewLogic/Models/MergeOptions.cs
@@ -1,0 +1,7 @@
+namespace AzurePrOps.ReviewLogic.Models;
+
+public record MergeOptions(
+    bool Squash,
+    bool DeleteSourceBranch,
+    string CommitMessage);
+

--- a/AzurePrOps/AzurePrOps.ReviewLogic/Services/Interfaces/IAzureDevOpsClient.cs
+++ b/AzurePrOps/AzurePrOps.ReviewLogic/Services/Interfaces/IAzureDevOpsClient.cs
@@ -47,4 +47,36 @@ public interface IAzureDevOpsClient
         int threadId,
         string status,
         string personalAccessToken);
+
+    Task SetPullRequestVoteAsync(
+        string organization,
+        string project,
+        string repositoryId,
+        int pullRequestId,
+        string reviewerId,
+        int vote,
+        string personalAccessToken);
+
+    Task SetPullRequestDraftAsync(
+        string organization,
+        string project,
+        string repositoryId,
+        int pullRequestId,
+        bool isDraft,
+        string personalAccessToken);
+
+    Task CompletePullRequestAsync(
+        string organization,
+        string project,
+        string repositoryId,
+        int pullRequestId,
+        MergeOptions mergeOptions,
+        string personalAccessToken);
+
+    Task AbandonPullRequestAsync(
+        string organization,
+        string project,
+        string repositoryId,
+        int pullRequestId,
+        string personalAccessToken);
 }


### PR DESCRIPTION
## Summary
- expand IAzureDevOpsClient with methods for voting, drafts, completion and abandonment
- wire up stub implementations in AzureDevOpsClient
- add simple MergeOptions record

## Testing
- `dotnet test AzurePrOps/AzurePrOps.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6885276a2fac8320a14e239ebeef5e1c