### PR TITLE
Add PR lifecycle commands

### DIFF
--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
@@ -128,6 +128,14 @@
                         Command="{Binding ShowInsightsCommand}"
                         ToolTip.Tip="View Analytics" />
                     <Button
+                        Classes="SecondaryButton"
+                        Content="Complete"
+                        Command="{Binding CompleteCommand}" />
+                    <Button
+                        Classes="DangerButton"
+                        Content="Abandon"
+                        Command="{Binding AbandonCommand}" />
+                    <Button
                         Classes="PrimaryButton"
                         Command="{Binding OpenInBrowserCommand}"
                         Content="🌐 Open in Browser"


### PR DESCRIPTION
## Summary
- enable completing or abandoning pull requests from the details view
- expose `CompleteCommand` and `AbandonCommand` in the details view model
- add Complete and Abandon buttons to the details window

## Testing
- `dotnet test AzurePrOps/AzurePrOps.Tests/AzurePrOps.Tests.csproj -v m`

------
https://chatgpt.com/codex/tasks/task_e_6885383dd3208320a17f79afbce24932