### PR TITLE
Enable feature flags by default; comment posting in details

### DIFF
--- a/AzurePrOps/AzurePrOps.Tests/FeatureFlagStorageTests.cs
+++ b/AzurePrOps/AzurePrOps.Tests/FeatureFlagStorageTests.cs
@@ -39,8 +39,8 @@ public class FeatureFlagStorageTests
         try
         {
             var loaded = FeatureFlagStorage.Load();
-            Assert.False(loaded.InlineCommentsEnabled);
-            Assert.False(loaded.LifecycleActionsEnabled);
+            Assert.True(loaded.InlineCommentsEnabled);
+            Assert.True(loaded.LifecycleActionsEnabled);
         }
         finally
         {

--- a/AzurePrOps/AzurePrOps/AzurePrOps.csproj
+++ b/AzurePrOps/AzurePrOps/AzurePrOps.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0" />
         <PackageReference Include="DiffPlex" Version="1.8.0" />
         <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
+        <PackageReference Include="Markdown.Avalonia" Version="11.0.2" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.6" />
     </ItemGroup>

--- a/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
+++ b/AzurePrOps/AzurePrOps/Controls/DiffViewer.axaml.cs
@@ -24,6 +24,7 @@ using DiffPlex.DiffBuilder;
 using DiffPlex.DiffBuilder.Model;
 using Microsoft.Extensions.Logging;
 using AzurePrOps.Logging;
+using Markdown.Avalonia;
 using System.IO;
 
 namespace AzurePrOps.Controls
@@ -755,11 +756,9 @@ namespace AzurePrOps.Controls
                         FontSize = 11,
                         FontWeight = FontWeight.SemiBold
                     });
-                    commentStack.Children.Add(new TextBlock
+                    commentStack.Children.Add(new MarkdownScrollViewer
                     {
-                        Text = c.Content,
-                        TextWrapping = TextWrapping.Wrap,
-                        FontSize = 12
+                        Markdown = c.Content
                     });
                     stack.Children.Add(commentStack);
                 }

--- a/AzurePrOps/AzurePrOps/Models/FeatureFlagStorage.cs
+++ b/AzurePrOps/AzurePrOps/Models/FeatureFlagStorage.cs
@@ -21,15 +21,15 @@ public static class FeatureFlagStorage
         try
         {
             if (!File.Exists(FilePath))
-                return new FeatureFlags(false, false);
+                return new FeatureFlags(true, true);
 
             var json = File.ReadAllText(FilePath);
             var data = JsonSerializer.Deserialize<FeatureFlags>(json);
-            return data ?? new FeatureFlags(false, false);
+            return data ?? new FeatureFlags(true, true);
         }
         catch
         {
-            return new FeatureFlags(false, false);
+            return new FeatureFlags(true, true);
         }
     }
 

--- a/AzurePrOps/AzurePrOps/ViewModels/CommentsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/CommentsWindowViewModel.cs
@@ -11,6 +11,7 @@ public class CommentsWindowViewModel : ViewModelBase
 {
     public string Title { get; }
     public ObservableCollection<PullRequestComment> Comments { get; }
+    public int CommentCount => Comments.Count;
     public ReactiveCommand<Unit, Unit> CloseCommand { get; }
 
     public CommentsWindowViewModel(string title, IEnumerable<PullRequestComment> comments)
@@ -18,6 +19,8 @@ public class CommentsWindowViewModel : ViewModelBase
         Title = title;
         Comments = new ObservableCollection<PullRequestComment>(
             comments.OrderByDescending(c => c.PostedDate));
+        Comments.CollectionChanged += (_, _) => this.RaisePropertyChanged(nameof(CommentCount));
+
         CloseCommand = ReactiveCommand.Create(() => { });
     }
 }

--- a/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
@@ -53,6 +53,14 @@ public class PullRequestDetailsWindowViewModel : ViewModelBase
     public ReactiveCommand<Unit, Unit> RefreshDiffsCommand { get; }
     public ReactiveCommand<Unit, Unit> CompleteCommand { get; }
     public ReactiveCommand<Unit, Unit> AbandonCommand { get; }
+    public ReactiveCommand<Unit, Unit> PostCommentCommand { get; }
+
+    private string _newCommentText = string.Empty;
+    public string NewCommentText
+    {
+        get => _newCommentText;
+        set => this.RaiseAndSetIfChanged(ref _newCommentText, value);
+    }
 
     public ObservableCollection<ReviewModels.FileDiff> FileDiffs { get; } = new();
 
@@ -195,6 +203,22 @@ public class PullRequestDetailsWindowViewModel : ViewModelBase
                 _settings.Repository,
                 PullRequest.Id,
                 _settings.PersonalAccessToken);
+        });
+
+        PostCommentCommand = ReactiveCommand.CreateFromTask(async () =>
+        {
+            if (string.IsNullOrWhiteSpace(NewCommentText))
+                return;
+
+            await _client.PostPullRequestCommentAsync(
+                _settings.Organization,
+                _settings.Project,
+                _settings.Repository,
+                PullRequest.Id,
+                NewCommentText,
+                _settings.PersonalAccessToken);
+
+            NewCommentText = string.Empty;
         });
     }
 

--- a/AzurePrOps/AzurePrOps/Views/CommentsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/CommentsWindow.axaml
@@ -5,6 +5,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="using:AzurePrOps.ViewModels"
     xmlns:model="using:AzurePrOps.AzureConnection.Models"
+    xmlns:md="clr-namespace:Markdown.Avalonia;assembly=Markdown.Avalonia"
     x:Class="AzurePrOps.Views.CommentsWindow"
     x:DataType="vm:CommentsWindowViewModel"
     mc:Ignorable="d"
@@ -19,42 +20,38 @@
             </vm:CommentsWindowViewModel.Comments>
         </vm:CommentsWindowViewModel>
     </Design.DataContext>
-    <StackPanel Margin="20" Spacing="12">
-        <TextBlock Text="{Binding Title}" FontSize="20" FontWeight="Bold" />
-        <ScrollViewer VerticalScrollBarVisibility="Auto"
+    <Grid Margin="20" RowDefinitions="Auto,*,Auto">
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <TextBlock Text="{Binding Title}" FontSize="20" FontWeight="Bold" />
+            <Border Background="{StaticResource PrimaryBrush}" CornerRadius="10" Padding="6,2"
+                    IsVisible="{Binding Comments, Converter={StaticResource CollectionNotEmptyConverter}}">
+                <TextBlock FontSize="11" FontWeight="Bold" Foreground="White" Text="{Binding CommentCount}"/>
+            </Border>
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
                       IsVisible="{Binding Comments, Converter={StaticResource CollectionNotEmptyConverter}}">
             <ItemsControl ItemsSource="{Binding Comments}" Margin="0,0,0,8">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="model:PullRequestComment">
-                        <Border
-                            Background="{StaticResource CardBackgroundBrush}"
-                            CornerRadius="6"
-                            Margin="0,0,0,8"
-                            Padding="10,8">
+                        <Border Background="{StaticResource CardBackgroundBrush}" CornerRadius="6" Margin="0,0,0,8" Padding="12,8">
                             <StackPanel Spacing="4">
                                 <Grid ColumnDefinitions="*,Auto">
-                                    <TextBlock Grid.Column="0"
-                                               FontSize="12"
-                                               FontWeight="SemiBold"
-                                               Text="{Binding Author}" />
-                                    <TextBlock Grid.Column="1"
-                                               FontSize="10"
-                                               Foreground="{StaticResource MutedBrush}"
-                                               Text="{Binding PostedDate}" />
+                                    <TextBlock Grid.Column="0" FontSize="12" FontWeight="SemiBold" Text="{Binding Author}" />
+                                    <TextBlock Grid.Column="1" FontSize="10" Foreground="{StaticResource MutedBrush}" Text="{Binding PostedDate}" />
                                 </Grid>
-                                <TextBlock FontSize="12"
-                                           Text="{Binding Content}"
-                                           TextWrapping="Wrap" />
+                                <md:MarkdownScrollViewer Markdown="{Binding Content}" />
                             </StackPanel>
                         </Border>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </ScrollViewer>
-        <TextBlock Text="No comments found"
-                   Foreground="{StaticResource MutedBrush}"
-                   HorizontalAlignment="Center"
+
+        <TextBlock Grid.Row="1" Text="No comments found" Foreground="{StaticResource MutedBrush}" HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
                    IsVisible="{Binding Comments, Converter={StaticResource CollectionNotEmptyConverter}, ConverterParameter=invert}" />
-        <Button Classes="PrimaryButton" Content="Close" Command="{Binding CloseCommand}" HorizontalAlignment="Right" Width="100" />
-    </StackPanel>
+
+        <Button Grid.Row="2" Classes="PrimaryButton" Content="Close" Command="{Binding CloseCommand}" HorizontalAlignment="Right" Width="100" />
+    </Grid>
 </Window>

--- a/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/PullRequestDetailsWindow.axaml
@@ -6,6 +6,7 @@
     x:Class="AzurePrOps.Views.PullRequestDetailsWindow"
     x:DataType="vm:PullRequestDetailsWindowViewModel"
     xmlns="https://github.com/avaloniaui"
+    xmlns:md="clr-namespace:Markdown.Avalonia;assembly=Markdown.Avalonia"
     xmlns:controls="using:AzurePrOps.Controls"
     xmlns:converters="using:AzurePrOps.Converters"
     xmlns:model="using:AzurePrOps.AzureConnection.Models"
@@ -230,17 +231,26 @@
                                                             Grid.Column="1"
                                                             Text="{Binding PostedDate}" />
                                                     </Grid>
-                                                    <TextBlock
-                                                        FontSize="12"
-                                                        MaxLines="3"
-                                                        Text="{Binding Content}"
-                                                        TextWrapping="Wrap" />
+                                                    <md:MarkdownScrollViewer
+                                                        MaxHeight="60"
+                                                        Markdown="{Binding Content}" />
                                                 </StackPanel>
                                             </Border>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
                             </ScrollViewer>
+                        </StackPanel>
+                    </Border>
+
+                    <!--  Add Comment  -->
+                    <Border Classes="Card">
+                        <StackPanel Spacing="12">
+                            <TextBlock FontSize="16" FontWeight="SemiBold" Text="Add Comment" />
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBox Text="{Binding NewCommentText}" Watermark="Enter your comment..." Width="200" />
+                                <Button Classes="PrimaryButton" Command="{Binding PostCommentCommand}" Content="Post" />
+                            </StackPanel>
                         </StackPanel>
                     </Border>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Opening files works across Linux and Windows for many popular IDEs such as VS Co
 
 ## Inline Comments
 
-Enable **Inline comments** from the Settings window to try inline commenting while reviewing diffs. Your Personal Access Token must include the **Code (Read & Write)** scope for posting replies.
+Inline commenting is enabled by default. Your Personal Access Token must include the **Code (Read & Write)** scope for posting replies. You can disable the feature from the Settings window if desired.
 
 When viewing a diff with the feature enabled, click in the gutter beside a line to open a popup showing existing threads. Enter text in the box to add a new comment or reply.
 
@@ -25,4 +25,4 @@ The sidebar lists all threads and can filter to only unresolved items.
 
 ## Lifecycle Actions
 
-Enable **Lifecycle actions** in Settings to show additional pull request controls. When enabled, the PR list displays your vote and a badge for draft PRs. Extra buttons allow approving with suggestions, waiting for the author, rejecting and more.
+Lifecycle actions are also on by default and add extra pull request controls. The PR list displays your vote and a badge for draft PRs, plus buttons for approving with suggestions, waiting for the author, rejecting and more.


### PR DESCRIPTION
## Summary
- allow writing comments directly in the PR details view
- enable all feature flags by default
- update tests and docs for new defaults
- overhaul comments window layout so long lists scroll properly
- render comments using Markdown so links and code blocks appear nicely

## Testing
- `dotnet test AzurePrOps/AzurePrOps.sln --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68854abd09708320803cf96221d471a8