### PR TITLE
Fix saved view selection binding

### DIFF
--- a/AzurePrOps/AzurePrOps/Views/MainWindow.axaml
+++ b/AzurePrOps/AzurePrOps/Views/MainWindow.axaml
@@ -420,9 +420,9 @@
 
                             <StackPanel Spacing="8">
                                 <ComboBox
-                                    ItemsSource="{Binding FilterViews}"
+                                    ItemsSource="{Binding SavedFilterViews}"
                                     PlaceholderText="No saved views..."
-                                    SelectedItem="{Binding SelectedFilterView}">
+                                    SelectedItem="{Binding SelectedSavedFilterView}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate>
                                             <TextBlock Text="{Binding Name}" />
@@ -438,7 +438,7 @@
                                         Watermark="View name..." />
                                     <Button
                                         Classes="SecondaryButton"
-                                        Command="{Binding SaveViewCommand}"
+                                        Command="{Binding SaveCurrentFiltersCommand}"
                                         Content="Save"
                                         Grid.Column="1"
                                         Width="50" />


### PR DESCRIPTION
## Summary
- bind Saved Views dropdown to new SavedFilterView collection and selection
- save current filters using SaveCurrentFiltersCommand

## Testing
- `dotnet test --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68baa75eb538832097838d0bbbbc5e53