### PR TITLE
Fix PR Details diff rendering and reduce initial load stalls

### DIFF
--- a/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
+++ b/AzurePrOps/AzurePrOps/ViewModels/PullRequestDetailsWindowViewModel.cs
@@ -78,7 +78,6 @@ public class PullRequestDetailsWindowViewModel : ViewModelBase
     
     private readonly Dictionary<string, FileDiffListItemViewModel> _fileDiffLookup = new(StringComparer.OrdinalIgnoreCase);
     private readonly SemaphoreSlim _diffLoadSemaphore = new(1, 1);
-    private CancellationTokenSource? _diffLoadCancellation;
 
     // Total metrics properties for overview section
     private int _filesChanged;
@@ -620,18 +619,6 @@ public class PullRequestDetailsWindowViewModel : ViewModelBase
         {
             _diffLoadSemaphore.Release();
         }
-    }
-
-    public CancellationToken BeginDiffContentLoad()
-    {
-        var oldCts = Interlocked.Exchange(ref _diffLoadCancellation, new CancellationTokenSource());
-        if (oldCts != null)
-        {
-            try { oldCts.Cancel(); } catch { }
-            oldCts.Dispose();
-        }
-
-        return _diffLoadCancellation.Token;
     }
 
     private ReviewModels.FileDiff BuildDiffContent(FileDiffListItemViewModel listItem)


### PR DESCRIPTION
## Summary
- fixed diff content loading cancellation so opening one file no longer cancels another file’s in-flight load
- fixed `DiffContainer` discovery in `PullRequestDetailsWindow` by targeting the named container instead of the first descendant `Border`
- removed unused per-load cancellation state from `PullRequestDetailsWindowViewModel`

## Root cause
1. Each expand action called `BeginDiffContentLoad()`, which canceled the previous token globally. During expand-all or fast clicks this canceled active loads, so many diff viewers never received content.
2. `CreateDiffViewerAsync` used `expander.FindDescendantOfType<Border>()`, which can return a header border instead of the actual content host, so the `DiffViewer` was sometimes injected into the wrong place.

## Validation
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release`
- `dotnet build AzurePrOps/AzurePrOps.sln -c Release --no-restore`
- `dotnet test AzurePrOps/AzurePrOps.Tests/AzurePrOps.Tests.csproj -c Release --no-build`

Build/test passed; only pre-existing warnings remain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996387f9f708320b8e907ffc6693b0f)